### PR TITLE
build(api): buf lint

### DIFF
--- a/api/buf.yaml
+++ b/api/buf.yaml
@@ -5,4 +5,4 @@ breaking:
     - FILE
 lint:
   use:
-    - DEFAULT
+    - STANDARD


### PR DESCRIPTION
WARN	Category DEFAULT referenced in your buf.yaml is deprecated. It has been replaced by category STANDARD.
