### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.340.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	git.jlel.se/jlelse/go-geouri v0.0.0-20210525190615-a9c1d50f42d6
 	github.com/IncSW/geoip2 v0.1.4
 	github.com/alexfalkowski/go-health/v2 v2.18.0
-	github.com/alexfalkowski/go-service/v2 v2.339.0
+	github.com/alexfalkowski/go-service/v2 v2.340.0
 	github.com/pariz/gountries v0.1.6
 	github.com/paulmach/orb v0.13.0
 	github.com/tidwall/rtree v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.18.0 h1:iSqrgmWdt/qaUNr/LsOvesehWFksAvHaM4Sy+O6RtTA=
 github.com/alexfalkowski/go-health/v2 v2.18.0/go.mod h1:9KSzMMK4aLqFoML8IfFoCEOxGsg5o2QY3GgI0E1FCLU=
-github.com/alexfalkowski/go-service/v2 v2.339.0 h1:+RBaTfijcV6tfTSBKhTUfUW9zj2BcbkJoXn9hN+RPH8=
-github.com/alexfalkowski/go-service/v2 v2.339.0/go.mod h1:OnqcdoVhuOcad+lSL2/HuP7JqMUnkks3nbxgFMUXbwg=
+github.com/alexfalkowski/go-service/v2 v2.340.0 h1:Of1g93VWEu712xrYT3yCv69u0CX4s+j90H9icuIalKY=
+github.com/alexfalkowski/go-service/v2 v2.340.0/go.mod h1:OnqcdoVhuOcad+lSL2/HuP7JqMUnkks3nbxgFMUXbwg=
 github.com/alexfalkowski/go-sync v1.19.3 h1:sEmPvRa08IjuQ44YpglQDhXpbex1YPQCwRkKqarejQc=
 github.com/alexfalkowski/go-sync v1.19.3/go.mod h1:J2yBCIWJ1YAWqAJ94Bt2xroR2rOWlSyRBGqqNJDmLBw=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.340.0
