### PR TITLE
docs(agents): document shared coding standards skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,12 @@
 # AGENTS.md
 
+## Shared skill
+
+Use the shared `coding-standards` skill from `./bin/skills/coding-standards`
+for cross-repository coding, review, testing, documentation, and PR
+conventions. Treat this `AGENTS.md` as the repo-specific companion to that
+skill.
+
 This repository is a Go service called **standort** (location-based information) with two API versions (v1 and v2) exposed over **gRPC** and **HTTP**.
 
 ## Recent repo notes (keep in sync)


### PR DESCRIPTION
## What
- Add a `Shared skill` section to [AGENTS.md](/Users/alejandro/code/alexfalkowski.github.io/AGENTS.md) telling agents to load `./bin/skills/coding-standards`.
- Clarify that `AGENTS.md` remains the repo-specific companion to the shared cross-repository guidance.

## Why
- Align this repo with the new shared skill so future coding, review, testing, documentation, and PR work follows the same baseline conventions.
- Keep shared guidance centralized in `./bin` while preserving repo-local instructions here.

## Testing
- Not run; this is a documentation-only change to agent instructions.