### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.354.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	git.jlel.se/jlelse/go-geouri v0.0.0-20210525190615-a9c1d50f42d6
 	github.com/IncSW/geoip2 v0.1.4
 	github.com/alexfalkowski/go-health/v2 v2.19.1
-	github.com/alexfalkowski/go-service/v2 v2.352.0
+	github.com/alexfalkowski/go-service/v2 v2.354.0
 	github.com/pariz/gountries v0.1.6
 	github.com/paulmach/orb v0.13.0
 	github.com/tidwall/rtree v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.19.1 h1:LS58hHOq3CbMFMf0DNp09t2AzDW0/H4TZ9KoXXxTQgo=
 github.com/alexfalkowski/go-health/v2 v2.19.1/go.mod h1:ypy+lqZpEh2HPNLqaDAv6wJBbxuouOZoPkkrtrMNXrA=
-github.com/alexfalkowski/go-service/v2 v2.352.0 h1:b/Al0tITKFao5EfmKcGFIkt2pcVwhVKR57rRRsyfQx0=
-github.com/alexfalkowski/go-service/v2 v2.352.0/go.mod h1:JWavyYKktE4NJgI7APCsHctzsAU4+mCXMsOXeOrmDkA=
+github.com/alexfalkowski/go-service/v2 v2.354.0 h1:rxTUutUixziiHiV+S+Djq24kjEpXEJNWgP4yQ5HiV7I=
+github.com/alexfalkowski/go-service/v2 v2.354.0/go.mod h1:JWavyYKktE4NJgI7APCsHctzsAU4+mCXMsOXeOrmDkA=
 github.com/alexfalkowski/go-sync v1.21.0 h1:Aydt3mB0FwmaRPjDsO4ZHJIa0HdueTwRt0i4NQtNvsA=
 github.com/alexfalkowski/go-sync v1.21.0/go.mod h1:J2yBCIWJ1YAWqAJ94Bt2xroR2rOWlSyRBGqqNJDmLBw=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.354.0
