### PR TITLE
fix(location): normalize unsupported continents

### DIFF
--- a/internal/location/continent/continent.go
+++ b/internal/location/continent/continent.go
@@ -13,6 +13,7 @@ package continent
 //   - AS: Asia
 //   - EU: Europe
 //   - SA: South America
+//   - AN: Antarctica
 //
 // This map is used by the domain `internal/location` service to normalize provider
 // outputs into stable API codes.
@@ -23,4 +24,5 @@ var Codes = map[string]string{
 	"Asia":          "AS",
 	"Europe":        "EU",
 	"South America": "SA",
+	"Antarctica":    "AN",
 }

--- a/internal/location/location.go
+++ b/internal/location/location.go
@@ -4,12 +4,17 @@ import (
 	"fmt"
 
 	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/standort/v2/internal/location/continent"
 	country "github.com/alexfalkowski/standort/v2/internal/location/country/provider"
 	ip "github.com/alexfalkowski/standort/v2/internal/location/ip/provider"
 	orb "github.com/alexfalkowski/standort/v2/internal/location/orb/provider"
 )
+
+// ErrUnsupportedContinent is returned when a provider resolves a continent name
+// that cannot be normalized to the API's two-letter continent code.
+var ErrUnsupportedContinent = errors.New("unsupported continent")
 
 // New constructs a domain `Location` service.
 //
@@ -58,7 +63,12 @@ func (l *Location) GetByIP(ctx context.Context, ip string) (string, string, erro
 		return strings.Empty, strings.Empty, err
 	}
 
-	return country, continent.Codes[cont], nil
+	code, err := continentCode(cont)
+	if err != nil {
+		return strings.Empty, strings.Empty, err
+	}
+
+	return country, code, nil
 }
 
 // GetByLatLng resolves a location from a latitude/longitude coordinate.
@@ -75,5 +85,19 @@ func (l *Location) GetByLatLng(ctx context.Context, lat, lng float64) (string, s
 		return strings.Empty, strings.Empty, fmt.Errorf("%f/%f: %w", lat, lng, err)
 	}
 
-	return cou, continent.Codes[con], nil
+	code, err := continentCode(con)
+	if err != nil {
+		return strings.Empty, strings.Empty, fmt.Errorf("%f/%f: %w", lat, lng, err)
+	}
+
+	return cou, code, nil
+}
+
+func continentCode(cont string) (string, error) {
+	code, ok := continent.Codes[cont]
+	if !ok {
+		return strings.Empty, fmt.Errorf("%s: %w", cont, ErrUnsupportedContinent)
+	}
+
+	return code, nil
 }

--- a/test/features/step_definitions/v2/transport/grpc/api_steps.rb
+++ b/test/features/step_definitions/v2/transport/grpc/api_steps.rb
@@ -26,7 +26,16 @@ Then('I should receive a valid locations with gRPC:') do |table|
   expect(@response.meta.length).to be > 0
 
   rows = table.rows_hash
-  location = @response.ip || @response.geo
+  location = case rows['kind']
+             when 'ip'
+               expect(@response.geo).to be_nil
+               @response.ip
+             when 'geo'
+               expect(@response.ip).to be_nil
+               @response.geo
+             else
+               raise "unsupported location kind: #{rows['kind']}"
+             end
 
   expect(location.country).to eq(rows['country'])
   expect(location.continent).to eq(rows['continent'])

--- a/test/features/step_definitions/v2/transport/grpc/benchmark_steps.rb
+++ b/test/features/step_definitions/v2/transport/grpc/benchmark_steps.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-When('I request a location with HTTP which performs in {int} ms') do |time|
+When('I request a location with gRPC which performs in {int} ms') do |time|
   @request_id = SecureRandom.uuid
   metadata = { 'request-id' => @request_id }
   params = { 'ip' => '95.91.246.242' }

--- a/test/features/step_definitions/v2/transport/http/api_steps.rb
+++ b/test/features/step_definitions/v2/transport/http/api_steps.rb
@@ -33,7 +33,10 @@ Then('I should receive a valid locations with HTTP:') do |table|
   expect(resp['meta'].length).to be > 0
 
   rows = table.rows_hash
-  location = resp['ip'] || resp['geo']
+  other = rows['kind'] == 'ip' ? 'geo' : 'ip'
+  location = resp.fetch(rows['kind'])
+
+  expect(resp[other]).to be_nil
 
   expect(location['country']).to eq(rows['country'])
   expect(location['continent']).to eq(rows['continent'])

--- a/test/features/step_definitions/v2/transport/http/benchmark_steps.rb
+++ b/test/features/step_definitions/v2/transport/http/benchmark_steps.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-When('I request a location with gRPC which performs in {int} ms') do |time|
+When('I request a location with HTTP which performs in {int} ms') do |time|
   @request_id = SecureRandom.uuid
   opts = {
     headers: {

--- a/test/features/v1/transport/grpc/api.feature
+++ b/test/features/v1/transport/grpc/api.feature
@@ -26,6 +26,7 @@ Feature: gRPC API
       | geoip2 | test    |
       | geoip2 | <test>  |
       | geoip2 |   154.6 |
+      | geoip2 | 1.0.4.1 |
 
   Scenario Outline: Get location by a valid latitude and longitude.
     When I request a location by latitude and longitude with gRPC:
@@ -36,10 +37,11 @@ Feature: gRPC API
       | continent | <continent> |
 
     Examples:
-      | latitude  | longitude  | country | continent |
-      | 52.520008 |  13.404954 | DE      | EU        |
-      | 52.377956 |   4.897070 | NL      | EU        |
-      | 43.000000 | -75.000000 | US      | NA        |
+      | latitude   | longitude  | country | continent |
+      |  52.520008 |  13.404954 | DE      | EU        |
+      |  52.377956 |   4.897070 | NL      | EU        |
+      |  43.000000 | -75.000000 | US      | NA        |
+      | -79.843222 |  35.885455 | AQ      | AN        |
 
   Scenario Outline: Get location by a not found latitude and longitude.
     When I request a location by latitude and longitude with gRPC:
@@ -48,7 +50,8 @@ Feature: gRPC API
     Then I should receive a not found response with gRPC
 
     Examples:
-      | latitude | longitude |
-      |       90 |       180 |
-      |       91 |        10 |
-      |       10 |       181 |
+      | latitude   | longitude |
+      |         90 |       180 |
+      |         91 |        10 |
+      |         10 |       181 |
+      | -49.303721 | 69.122136 |

--- a/test/features/v1/transport/http/api.feature
+++ b/test/features/v1/transport/http/api.feature
@@ -26,6 +26,7 @@ Feature: HTTP API
       | geoip2 | test    |
       | geoip2 | <test>  |
       | geoip2 |   154.6 |
+      | geoip2 | 1.0.4.1 |
       | geoip2 |         |
 
   Scenario Outline: Get location by a valid latitude and longitude.
@@ -37,10 +38,11 @@ Feature: HTTP API
       | continent | <continent> |
 
     Examples:
-      | latitude  | longitude  | country | continent |
-      | 52.520008 |  13.404954 | DE      | EU        |
-      | 52.377956 |   4.897070 | NL      | EU        |
-      | 43.000000 | -75.000000 | US      | NA        |
+      | latitude   | longitude  | country | continent |
+      |  52.520008 |  13.404954 | DE      | EU        |
+      |  52.377956 |   4.897070 | NL      | EU        |
+      |  43.000000 | -75.000000 | US      | NA        |
+      | -79.843222 |  35.885455 | AQ      | AN        |
 
   Scenario Outline: Get location by a not found latitude and longitude.
     When I request a location by latitude and longitude with HTTP:
@@ -49,7 +51,8 @@ Feature: HTTP API
     Then I should receive a not found response with HTTP
 
     Examples:
-      | latitude | longitude |
-      |       90 |       180 |
-      |       91 |        10 |
-      |       10 |       181 |
+      | latitude   | longitude |
+      |         90 |       180 |
+      |         91 |        10 |
+      |         10 |       181 |
+      | -49.303721 | 69.122136 |

--- a/test/features/v2/transport/grpc/api.feature
+++ b/test/features/v2/transport/grpc/api.feature
@@ -12,17 +12,17 @@ Feature: gRPC API
       | continent | <continent> |
 
     Examples: With geoip2 parameters
-      | source | method | ip                                      | country | continent |
-      | geoip2 | params |                           95.91.246.242 | DE      | EU        |
-      | geoip2 | params |                          45.128.199.236 | NL      | EU        |
-      | geoip2 | params |                             154.6.22.65 | US      | NA        |
-      | geoip2 | params | 2a02:8109:9f2e:4600:861e:b845:8bd4:b047 | DE      | EU        |
+      | source | method | kind | ip                                      | country | continent |
+      | geoip2 | params | ip   |                           95.91.246.242 | DE      | EU        |
+      | geoip2 | params | ip   |                          45.128.199.236 | NL      | EU        |
+      | geoip2 | params | ip   |                             154.6.22.65 | US      | NA        |
+      | geoip2 | params | ip   | 2a02:8109:9f2e:4600:861e:b845:8bd4:b047 | DE      | EU        |
 
     Examples: With geoip2 metadata
-      | source | method   | ip             | country | continent |
-      | geoip2 | metadata |  95.91.246.242 | DE      | EU        |
-      | geoip2 | metadata | 45.128.199.236 | NL      | EU        |
-      | geoip2 | metadata |    154.6.22.65 | US      | NA        |
+      | source | method   | kind | ip             | country | continent |
+      | geoip2 | metadata | ip   |  95.91.246.242 | DE      | EU        |
+      | geoip2 | metadata | ip   | 45.128.199.236 | NL      | EU        |
+      | geoip2 | metadata | ip   |    154.6.22.65 | US      | NA        |
 
   Scenario Outline: Get location by a not found IP address.
     When I request a location with gRPC:
@@ -35,14 +35,16 @@ Feature: gRPC API
       | geoip2 | params | 0.0.0.0 |
       | geoip2 | params | test    |
       | geoip2 | params | <test>  |
-      | geoip2 | params |   154.6 |
+      | geoip2 | params | 154.6   |
+      | geoip2 | params | 1.0.4.1 |
 
     Examples: With geoip2 metadata
       | source | method   | ip      |
       | geoip2 | metadata | 0.0.0.0 |
       | geoip2 | metadata | test    |
       | geoip2 | metadata | <test>  |
-      | geoip2 | metadata |   154.6 |
+      | geoip2 | metadata | 154.6   |
+      | geoip2 | metadata | 1.0.4.1 |
 
   Scenario Outline: Get location by a valid latitude and longitude.
     When I request a location with gRPC:
@@ -55,16 +57,16 @@ Feature: gRPC API
       | continent | <continent> |
 
     Examples: With parameters
-      | method | latitude  | longitude  | country | continent |
-      | params | 52.520008 |  13.404954 | DE      | EU        |
-      | params | 52.377956 |   4.897070 | NL      | EU        |
-      | params | 43.000000 | -75.000000 | US      | NA        |
+      | method | kind | latitude  | longitude  | country | continent |
+      | params | geo  | 52.520008 |  13.404954 | DE      | EU        |
+      | params | geo  | 52.377956 |   4.897070 | NL      | EU        |
+      | params | geo  | 43.000000 | -75.000000 | US      | NA        |
 
     Examples: With metadata
-      | method   | latitude  | longitude  | country | continent |
-      | metadata | 52.520008 |  13.404954 | DE      | EU        |
-      | metadata | 52.377956 |   4.897070 | NL      | EU        |
-      | metadata | 43.000000 | -75.000000 | US      | NA        |
+      | method   | kind | latitude  | longitude  | country | continent |
+      | metadata | geo  | 52.520008 |  13.404954 | DE      | EU        |
+      | metadata | geo  | 52.377956 |   4.897070 | NL      | EU        |
+      | metadata | geo  | 43.000000 | -75.000000 | US      | NA        |
 
   Scenario Outline: Get location by a bad latitude and longitude.
     When I request a location with gRPC:
@@ -93,6 +95,8 @@ Feature: gRPC API
     Then I should receive a not found response with gRPC
 
     Examples:
-      | method   | latitude | longitude |
-      | params   |       90 |       180 |
-      | metadata |       90 |       180 |
+      | method   | latitude   | longitude |
+      | params   | 90         | 180       |
+      | metadata | 90         | 180       |
+      | params   | -49.303721 | 69.122136 |
+      | metadata | -49.303721 | 69.122136 |

--- a/test/features/v2/transport/http/api.feature
+++ b/test/features/v2/transport/http/api.feature
@@ -12,16 +12,16 @@ Feature: HTTP API
       | continent | <continent> |
 
     Examples: With geoip2 parameters
-      | source | method | ip             | country | continent |
-      | geoip2 | params |  95.91.246.242 | DE      | EU        |
-      | geoip2 | params | 45.128.199.236 | NL      | EU        |
-      | geoip2 | params |    154.6.22.65 | US      | NA        |
+      | source | method | kind | ip             | country | continent |
+      | geoip2 | params | ip   |  95.91.246.242 | DE      | EU        |
+      | geoip2 | params | ip   | 45.128.199.236 | NL      | EU        |
+      | geoip2 | params | ip   |    154.6.22.65 | US      | NA        |
 
     Examples: With geoip2 headers
-      | source | method  | ip             | country | continent |
-      | geoip2 | headers |  95.91.246.242 | DE      | EU        |
-      | geoip2 | headers | 45.128.199.236 | NL      | EU        |
-      | geoip2 | headers |    154.6.22.65 | US      | NA        |
+      | source | method  | kind | ip             | country | continent |
+      | geoip2 | headers | ip   |  95.91.246.242 | DE      | EU        |
+      | geoip2 | headers | ip   | 45.128.199.236 | NL      | EU        |
+      | geoip2 | headers | ip   |    154.6.22.65 | US      | NA        |
 
   Scenario Outline: Get location by an bad IP address.
     When I request a location with HTTP:
@@ -34,14 +34,16 @@ Feature: HTTP API
       | geoip2 | params | 0.0.0.0 |
       | geoip2 | params | test    |
       | geoip2 | params | <test>  |
-      | geoip2 | params |   154.6 |
+      | geoip2 | params | 154.6   |
+      | geoip2 | params | 1.0.4.1 |
 
     Examples: With ip2location headers
       | source | method  | ip      |
       | geoip2 | headers | 0.0.0.0 |
       | geoip2 | headers | test    |
       | geoip2 | headers | <test>  |
-      | geoip2 | headers |   154.6 |
+      | geoip2 | headers | 154.6   |
+      | geoip2 | headers | 1.0.4.1 |
 
   Scenario Outline: Get location by a valid latitude and longitude.
     When I request a location with HTTP:
@@ -54,16 +56,16 @@ Feature: HTTP API
       | continent | <continent> |
 
     Examples: With parameters
-      | method | latitude  | longitude  | country | continent |
-      | params | 52.520008 |  13.404954 | DE      | EU        |
-      | params | 52.377956 |   4.897070 | NL      | EU        |
-      | params | 43.000000 | -75.000000 | US      | NA        |
+      | method | kind | latitude  | longitude  | country | continent |
+      | params | geo  | 52.520008 |  13.404954 | DE      | EU        |
+      | params | geo  | 52.377956 |   4.897070 | NL      | EU        |
+      | params | geo  | 43.000000 | -75.000000 | US      | NA        |
 
     Examples: With headers
-      | method  | latitude  | longitude  | country | continent |
-      | headers | 52.520008 |  13.404954 | DE      | EU        |
-      | headers | 52.377956 |   4.897070 | NL      | EU        |
-      | headers | 43.000000 | -75.000000 | US      | NA        |
+      | method  | kind | latitude  | longitude  | country | continent |
+      | headers | geo  | 52.520008 |  13.404954 | DE      | EU        |
+      | headers | geo  | 52.377956 |   4.897070 | NL      | EU        |
+      | headers | geo  | 43.000000 | -75.000000 | US      | NA        |
 
   Scenario Outline: Get location by a bad latitude and longitude.
     When I request a location with HTTP:
@@ -92,6 +94,8 @@ Feature: HTTP API
     Then I should receive a not found response with HTTP
 
     Examples:
-      | method  | latitude | longitude |
-      | params  |       90 |       180 |
-      | headers |       90 |       180 |
+      | method  | latitude   | longitude |
+      | params  | 90         | 180       |
+      | headers | 90         | 180       |
+      | params  | -49.303721 | 69.122136 |
+      | headers | -49.303721 | 69.122136 |


### PR DESCRIPTION
## What

- return an explicit unsupported-continent error when provider output cannot be mapped to an API continent code
- add Antarctica to the continent code map as AN
- correct v2 benchmark step bindings so HTTP and gRPC scenarios exercise the intended clients
- assert v2 API result kind in the existing feature steps

## Why

This prevents successful responses with empty continent codes, keeps benchmark coverage pointed at the right transport, and makes the existing v2 kind examples enforce the response branch they describe.

## Testing

- `make specs`
- `make features`
- `make benchmarks`
- `make lint`

AI-assisted-by: [Codex](https://openai.com/codex/)
