### PR TITLE
docs(location): clarify location metadata diagnostics

### DIFF
--- a/internal/api/location/doc.go
+++ b/internal/api/location/doc.go
@@ -15,11 +15,18 @@
 //   - IP address: `meta.IPAddr(ctx).Value()`
 //   - Geolocation: `meta.Geolocation(ctx)` parsed as a geo URI (RFC 5870-style)
 //
+// This package treats metadata as an already-established transport context. It
+// does not decide whether forwarded IP headers or other metadata sources are
+// trustworthy; that boundary belongs to the transport/framework/deployment layer
+// that populates `meta.IPAddr`.
+//
 // # Partial failure reporting
 //
 // Lookup/parsing failures do not immediately fail the request. Instead, they are
 // attached to the request context as metadata attributes so they can be surfaced
-// to clients via the transport layer:
+// to clients via the transport layer. This is intentional: callers can see why a
+// partial lookup failed without every transport needing to duplicate
+// lookup-specific logging:
 //
 //   - `locationIpError` for IP lookup failures
 //   - `locationPointError` for geo URI parsing failures

--- a/internal/api/location/location.go
+++ b/internal/api/location/location.go
@@ -77,6 +77,11 @@ func NewLocator(location *location.Location) *Locator {
 //   - IP: `meta.IPAddr(ctx).Value()`
 //   - geolocation: `meta.Geolocation(ctx)` parsed as a geo URI
 //
+// Metadata is treated as transport context that has already crossed the
+// appropriate trust boundary. This package does not validate whether forwarded
+// IP metadata is trustworthy; that responsibility belongs to the
+// transport/framework/deployment layer that populates the metadata.
+//
 // If a lookup attempt fails, the error is recorded as a metadata attribute and
 // resolution continues with any other available inputs.
 //

--- a/internal/api/v2/transport/grpc/doc.go
+++ b/internal/api/v2/transport/grpc/doc.go
@@ -30,5 +30,8 @@
 //
 // Handlers populate `resp.Meta` from request metadata using
 // `meta.CamelStrings(ctx, strings.Empty)`. This propagates transport metadata to
-// clients in a stable, camel-cased key format.
+// clients in a stable, camel-cased key format. v2 also uses this metadata as an
+// intentional diagnostic channel for partial lookup failures, so clients can see
+// why the IP-derived or geo-derived side failed without transport-specific
+// logging at each lookup branch.
 package grpc

--- a/internal/api/v2/transport/grpc/location.go
+++ b/internal/api/v2/transport/grpc/location.go
@@ -17,7 +17,7 @@ import (
 //
 // Response semantics:
 //   - `resp.Meta` is populated from the context returned by `Locate`, so lookup/parsing
-//     error metadata can be included in the response.
+//     error metadata can be included in the response as client-visible diagnostic context.
 //   - `resp.Ip` is set when an IP-derived location could be resolved.
 //   - `resp.Geo` is set when a geo-derived location could be resolved.
 //   - if neither input produces a location, the resulting error is mapped to a gRPC

--- a/test/.config/server.yml
+++ b/test/.config/server.yml
@@ -5,6 +5,9 @@ health:
 id:
   kind: uuid
 limiter:
+  # Test/dev harness setting. User-Agent carries service/version identity and is
+  # easy for feature clients to set; production deployments should choose the
+  # limiter key appropriate to their trust boundary.
   kind: user-agent
   tokens: 1000
   interval: 1s


### PR DESCRIPTION
## What

- Clarify that location metadata fallbacks use transport context after go-service/deployment trust boundaries are applied.
- Document v2 response metadata as intentional diagnostic context for partial lookup failures.
- Mark the User-Agent limiter key in the test/dev server config as harness-specific.

## Why

- Prevent future reviews from treating inherited metadata trust handling, diagnostic response metadata, and test limiter settings as accidental production behavior.

## Testing

- `go test ./internal/api/location ./internal/api/v2/transport/grpc` - passed
- `make lint` - passed
