### PR TITLE
feat(security): validate config and normalize geo codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vendor
 /standort
 dist
 .source-key
+ISSUES.md

--- a/internal/health/doc.go
+++ b/internal/health/doc.go
@@ -15,6 +15,18 @@
 // `Config` (see `config.go`) and is expected to be provided by the application's
 // configuration system.
 //
+// # Health semantics
+//
+// The HTTP `healthz` observer intentionally uses go-health's `online` checker.
+// That checker verifies public internet reachability using its default URL set
+// when no custom URLs are supplied. This is a product/operational signal for
+// standort, not an accidental external dependency: `healthz` is expected to
+// report unhealthy when the process cannot reach the public internet.
+//
+// Liveness and readiness are separate local signals. The HTTP `livez` and
+// `readyz` observers, as well as the Standort gRPC service observers, use the
+// local `noop` checker and do not require public egress.
+//
 // # Dependency injection
 //
 // This package exports `Module`, which registers the check registration and

--- a/internal/location/orb/provider/rtree/rtree.go
+++ b/internal/location/orb/provider/rtree/rtree.go
@@ -84,13 +84,40 @@ func populateTree(tree *rtree.Generic[*Node], fs embed.FS) {
 	runtime.Must(err)
 
 	for _, f := range fc.Features {
+		country := countryCode(f.Properties)
+		if strings.IsEmpty(country) {
+			continue
+		}
+
 		bound := f.Geometry.Bound()
 		data := &Node{
-			Country:   f.Properties["iso_a2"].(string),
+			Country:   country,
 			Continent: f.Properties["continent"].(string),
 			Geometry:  f.Geometry,
 		}
 
 		tree.Insert(bound.Min, bound.Max, data)
 	}
+}
+
+func countryCode(properties map[string]any) string {
+	if code := validCountryCode(properties["iso_a2"]); !strings.IsEmpty(code) {
+		return code
+	}
+
+	return validCountryCode(properties["iso_a2_eh"])
+}
+
+func validCountryCode(value any) string {
+	code, ok := value.(string)
+	if !ok || len(code) != 2 {
+		return strings.Empty
+	}
+	for _, r := range code {
+		if r < 'A' || r > 'Z' {
+			return strings.Empty
+		}
+	}
+
+	return code
 }


### PR DESCRIPTION
## What

- Require the Standort health and embedded base config during config validation.
- Document that HTTP `healthz` intentionally uses the online checker while readiness, liveness, and gRPC health remain local.
- Normalize R-tree GeoJSON country codes by rejecting placeholder values and falling back to `iso_a2_eh` when valid.
- Ignore scoped `ISSUES.md` ledgers after the issue workflow is complete.

## Why

- Prevent missing config sections from reaching startup dereferences.
- Keep intentional health semantics visible to future reviewers.
- Avoid returning Natural Earth `-99` placeholders as API country codes.

## Testing

- `go test ./internal/config ./internal/health ./internal/location/...` - passed
- `make lint` - passed
- `make features` - passed
