### PR TITLE
test(feature): cover combined responses and metadata

### DIFF
--- a/test/features/health/transport/grpc/observability.feature
+++ b/test/features/health/transport/grpc/observability.feature
@@ -3,6 +3,11 @@ Feature: Observability
 
   Observability is a measure of how well internal states of a system can be inferred by knowledge of its external outputs.
 
-  Scenario: Health with gRPC
-    When the system requests the health status with gRPC
+  Scenario Outline: Health with gRPC
+    When the system requests the "<service>" health status with gRPC
     Then the system should respond with a healthy status with gRPC
+
+    Examples:
+      | service             |
+      | standort.v1.Service |
+      | standort.v2.Service |

--- a/test/features/step_definitions/health/transport/grpc/observability_steps.rb
+++ b/test/features/step_definitions/health/transport/grpc/observability_steps.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-When('the system requests the health status with gRPC') do
-  request = Grpc::Health::V1::HealthCheckRequest.new(service: 'standort.v2.Service')
+When('the system requests the {string} health status with gRPC') do |service|
+  request = Grpc::Health::V1::HealthCheckRequest.new(service:)
   @response = Standort.health_grpc.check(request)
 end
 

--- a/test/features/step_definitions/v1/transport/grpc/api_steps.rb
+++ b/test/features/step_definitions/v1/transport/grpc/api_steps.rb
@@ -25,7 +25,7 @@ end
 Then('I should receive a valid location by IP adress with gRPC:') do |table|
   rows = table.rows_hash
 
-  expect(@response.meta.length).to be > 0
+  expect(@response.meta['requestId']).to eq(@request_id)
   expect(@response.location.country).to eq(rows['country'])
   expect(@response.location.continent).to eq(rows['continent'])
 end
@@ -37,7 +37,7 @@ end
 Then('I should receive a valid location by latitude and longitude with gRPC:') do |table|
   rows = table.rows_hash
 
-  expect(@response.meta.length).to be > 0
+  expect(@response.meta['requestId']).to eq(@request_id)
   expect(@response.location.country).to eq(rows['country'])
   expect(@response.location.continent).to eq(rows['continent'])
 end

--- a/test/features/step_definitions/v1/transport/http/api_steps.rb
+++ b/test/features/step_definitions/v1/transport/http/api_steps.rb
@@ -2,9 +2,10 @@
 
 When('I request a location by IP address with HTTP:') do |table|
   rows = table.rows_hash
+  @request_id = SecureRandom.uuid
   opts = {
     headers: {
-      request_id: SecureRandom.uuid, user_agent: Standort.config.transport.http.user_agent,
+      request_id: @request_id, user_agent: Standort.config.transport.http.user_agent,
       content_type: :json, accept: :json
     },
     read_timeout: 10, open_timeout: 10
@@ -15,9 +16,10 @@ end
 
 When('I request a location by latitude and longitude with HTTP:') do |table|
   rows = table.rows_hash
+  @request_id = SecureRandom.uuid
   opts = {
     headers: {
-      request_id: SecureRandom.uuid, user_agent: Standort.config.transport.http.user_agent,
+      request_id: @request_id, user_agent: Standort.config.transport.http.user_agent,
       content_type: :json, accept: :json
     },
     read_timeout: 10, open_timeout: 10
@@ -33,7 +35,7 @@ Then('I should receive a valid location by IP adress with HTTP:') do |table|
   location = resp['location']
   rows = table.rows_hash
 
-  expect(resp['meta'].length).to be > 0
+  expect(resp.fetch('meta').fetch('requestId')).to eq(@request_id)
   expect(location['country']).to eq(rows['country'])
   expect(location['continent']).to eq(rows['continent'])
 end
@@ -49,7 +51,7 @@ Then('I should receive a valid location by latitude and longitude with HTTP:') d
   location = resp['location']
   rows = table.rows_hash
 
-  expect(resp['meta'].length).to be > 0
+  expect(resp.fetch('meta').fetch('requestId')).to eq(@request_id)
   expect(location['country']).to eq(rows['country'])
   expect(location['continent']).to eq(rows['continent'])
 end

--- a/test/features/step_definitions/v2/transport/grpc/api_steps.rb
+++ b/test/features/step_definitions/v2/transport/grpc/api_steps.rb
@@ -23,7 +23,7 @@ rescue StandardError => e
 end
 
 Then('I should receive a valid locations with gRPC:') do |table|
-  expect(@response.meta.length).to be > 0
+  expect(@response.meta['requestId']).to eq(@request_id)
 
   rows = table.rows_hash
   location = case rows['kind']
@@ -37,6 +37,44 @@ Then('I should receive a valid locations with gRPC:') do |table|
                raise "unsupported location kind: #{rows['kind']}"
              end
 
+  expect(location.country).to eq(rows['country'])
+  expect(location.continent).to eq(rows['continent'])
+end
+
+Then('I should receive valid locations with gRPC:') do |table|
+  expect(@response.meta['requestId']).to eq(@request_id)
+
+  table.hashes.each do |row|
+    location = case row['kind']
+               when 'ip'
+                 @response.ip
+               when 'geo'
+                 @response.geo
+               else
+                 raise "unsupported location kind: #{row['kind']}"
+               end
+
+    expect(location.country).to eq(row['country'])
+    expect(location.continent).to eq(row['continent'])
+  end
+end
+
+Then('I should receive a partial location with gRPC:') do |table|
+  expect(@response.meta['requestId']).to eq(@request_id)
+
+  rows = table.rows_hash
+  location = case rows['kind']
+             when 'ip'
+               expect(@response.geo).to be_nil
+               @response.ip
+             when 'geo'
+               expect(@response.ip).to be_nil
+               @response.geo
+             else
+               raise "unsupported location kind: #{rows['kind']}"
+             end
+
+  expect(@response.meta).to include(rows['error'])
   expect(location.country).to eq(rows['country'])
   expect(location.continent).to eq(rows['continent'])
 end

--- a/test/features/step_definitions/v2/transport/http/api_steps.rb
+++ b/test/features/step_definitions/v2/transport/http/api_steps.rb
@@ -2,9 +2,10 @@
 
 When('I request a location with HTTP:') do |table|
   rows = table.rows_hash
+  @request_id = SecureRandom.uuid
   opts = {
     headers: {
-      request_id: SecureRandom.uuid, user_agent: 'Standort-ruby-client/2.0 HTTP/1.0',
+      request_id: @request_id, user_agent: 'Standort-ruby-client/2.0 HTTP/1.0',
       content_type: :json, accept: :json
     },
     read_timeout: 10, open_timeout: 10
@@ -30,7 +31,7 @@ Then('I should receive a valid locations with HTTP:') do |table|
 
   resp = JSON.parse(@response.body)
 
-  expect(resp['meta'].length).to be > 0
+  expect(resp.fetch('meta').fetch('requestId')).to eq(@request_id)
 
   rows = table.rows_hash
   other = rows['kind'] == 'ip' ? 'geo' : 'ip'
@@ -38,6 +39,36 @@ Then('I should receive a valid locations with HTTP:') do |table|
 
   expect(resp[other]).to be_nil
 
+  expect(location['country']).to eq(rows['country'])
+  expect(location['continent']).to eq(rows['continent'])
+end
+
+Then('I should receive valid locations with HTTP:') do |table|
+  expect(@response.code).to eq(200)
+
+  resp = JSON.parse(@response.body)
+
+  expect(resp.fetch('meta').fetch('requestId')).to eq(@request_id)
+
+  table.hashes.each do |row|
+    location = resp.fetch(row['kind'])
+
+    expect(location['country']).to eq(row['country'])
+    expect(location['continent']).to eq(row['continent'])
+  end
+end
+
+Then('I should receive a partial location with HTTP:') do |table|
+  expect(@response.code).to eq(200)
+
+  resp = JSON.parse(@response.body)
+  rows = table.rows_hash
+  other = rows['kind'] == 'ip' ? 'geo' : 'ip'
+  location = resp.fetch(rows['kind'])
+
+  expect(resp[other]).to be_nil
+  expect(resp.fetch('meta')).to include(rows['error'])
+  expect(resp.fetch('meta').fetch('requestId')).to eq(@request_id)
   expect(location['country']).to eq(rows['country'])
   expect(location['continent']).to eq(rows['continent'])
 end

--- a/test/features/step_definitions/v2/transport/http/benchmark_steps.rb
+++ b/test/features/step_definitions/v2/transport/http/benchmark_steps.rb
@@ -4,12 +4,21 @@ When('I request a location with HTTP which performs in {int} ms') do |time|
   @request_id = SecureRandom.uuid
   opts = {
     headers: {
-      request_id: SecureRandom.uuid, user_agent: 'Standort-ruby-client/2.0 HTTP/1.0',
+      request_id: @request_id, user_agent: 'Standort-ruby-client/2.0 HTTP/1.0',
       content_type: :json, accept: :json
     },
     read_timeout: 10, open_timeout: 10
   }
-  params = { 'ip' => '95.91.246.242' }
+  params = { ip: '95.91.246.242' }
+  response = nil
 
-  expect { Standort::V2.http.get_location(params, opts) }.to perform_under(time).ms
+  expect { response = Standort::V2.http.get_location(params, opts) }.to perform_under(time).ms
+
+  body = JSON.parse(response.body)
+
+  expect(response.code).to eq(200)
+  expect(body.fetch('meta').fetch('requestId')).to eq(@request_id)
+  expect(body.fetch('ip').fetch('country')).to eq('DE')
+  expect(body.fetch('ip').fetch('continent')).to eq('EU')
+  expect(body['geo']).to be_nil
 end

--- a/test/features/v2/transport/grpc/api.feature
+++ b/test/features/v2/transport/grpc/api.feature
@@ -68,6 +68,42 @@ Feature: gRPC API
       | metadata | geo  | 52.377956 |   4.897070 | NL      | EU        |
       | metadata | geo  | 43.000000 | -75.000000 | US      | NA        |
 
+  Scenario Outline: Get location by a valid IP address and latitude and longitude.
+    When I request a location with gRPC:
+      | ip        | <ip>        |
+      | latitude  | <latitude>  |
+      | longitude | <longitude> |
+      | method    | <method>    |
+    Then I should receive valid locations with gRPC:
+      | kind | country       | continent       |
+      | ip   | <ip_country>  | <ip_continent>  |
+      | geo  | <geo_country> | <geo_continent> |
+
+    Examples: With parameters
+      | method | ip            | latitude  | longitude | ip_country | ip_continent | geo_country | geo_continent |
+      | params | 95.91.246.242 | 52.377956 |  4.897070 | DE         | EU           | NL          | EU            |
+
+  Scenario Outline: Get location by partially valid inputs.
+    When I request a location with gRPC:
+      | ip        | <ip>        |
+      | latitude  | <latitude>  |
+      | longitude | <longitude> |
+      | method    | <method>    |
+    Then I should receive a partial location with gRPC:
+      | kind      | <kind>      |
+      | country   | <country>   |
+      | continent | <continent> |
+      | error     | <error>     |
+
+    Examples: With parameters
+      | method | kind | ip            | latitude  | longitude | country | continent | error               |
+      | params | geo  | 0.0.0.0       | 52.377956 |  4.897070 | NL      | EU        | locationIpError     |
+      | params | ip   | 95.91.246.242 | 91        | 10        | DE      | EU        | locationLatLngError |
+
+    Examples: With metadata
+      | method   | kind | ip            | latitude | longitude | country | continent | error              |
+      | metadata | ip   | 95.91.246.242 | test     | 180       | DE      | EU        | locationPointError |
+
   Scenario Outline: Get location by a bad latitude and longitude.
     When I request a location with gRPC:
       | latitude  | <latitude>  |

--- a/test/features/v2/transport/http/api.feature
+++ b/test/features/v2/transport/http/api.feature
@@ -34,7 +34,7 @@ Feature: HTTP API
       | geoip2 | params | 0.0.0.0 |
       | geoip2 | params | test    |
       | geoip2 | params | <test>  |
-      | geoip2 | params | 154.6   |
+      | geoip2 | params |   154.6 |
       | geoip2 | params | 1.0.4.1 |
 
     Examples: With ip2location headers
@@ -42,7 +42,7 @@ Feature: HTTP API
       | geoip2 | headers | 0.0.0.0 |
       | geoip2 | headers | test    |
       | geoip2 | headers | <test>  |
-      | geoip2 | headers | 154.6   |
+      | geoip2 | headers |   154.6 |
       | geoip2 | headers | 1.0.4.1 |
 
   Scenario Outline: Get location by a valid latitude and longitude.
@@ -66,6 +66,42 @@ Feature: HTTP API
       | headers | geo  | 52.520008 |  13.404954 | DE      | EU        |
       | headers | geo  | 52.377956 |   4.897070 | NL      | EU        |
       | headers | geo  | 43.000000 | -75.000000 | US      | NA        |
+
+  Scenario Outline: Get location by a valid IP address and latitude and longitude.
+    When I request a location with HTTP:
+      | ip        | <ip>        |
+      | latitude  | <latitude>  |
+      | longitude | <longitude> |
+      | method    | <method>    |
+    Then I should receive valid locations with HTTP:
+      | kind | country       | continent       |
+      | ip   | <ip_country>  | <ip_continent>  |
+      | geo  | <geo_country> | <geo_continent> |
+
+    Examples: With parameters
+      | method | ip            | latitude  | longitude | ip_country | ip_continent | geo_country | geo_continent |
+      | params | 95.91.246.242 | 52.377956 |  4.897070 | DE         | EU           | NL          | EU            |
+
+  Scenario Outline: Get location by partially valid inputs.
+    When I request a location with HTTP:
+      | ip        | <ip>        |
+      | latitude  | <latitude>  |
+      | longitude | <longitude> |
+      | method    | <method>    |
+    Then I should receive a partial location with HTTP:
+      | kind      | <kind>      |
+      | country   | <country>   |
+      | continent | <continent> |
+      | error     | <error>     |
+
+    Examples: With parameters
+      | method | kind | ip            | latitude  | longitude | country | continent | error               |
+      | params | geo  |       0.0.0.0 | 52.377956 |  4.897070 | NL      | EU        | locationIpError     |
+      | params | ip   | 95.91.246.242 |        91 |        10 | DE      | EU        | locationLatLngError |
+
+    Examples: With headers
+      | method  | kind | ip            | latitude | longitude | country | continent | error              |
+      | headers | ip   | 95.91.246.242 | test     |       180 | DE      | EU        | locationPointError |
 
   Scenario Outline: Get location by a bad latitude and longitude.
     When I request a location with HTTP:
@@ -95,7 +131,7 @@ Feature: HTTP API
 
     Examples:
       | method  | latitude   | longitude |
-      | params  | 90         | 180       |
-      | headers | 90         | 180       |
+      | params  |         90 |       180 |
+      | headers |         90 |       180 |
       | params  | -49.303721 | 69.122136 |
       | headers | -49.303721 | 69.122136 |


### PR DESCRIPTION
## What

- Add v2 HTTP and gRPC scenarios for combined IP/geo responses and partial-success diagnostics.
- Assert request ID metadata propagation across v1/v2 HTTP and gRPC success paths.
- Cover both gRPC health service registrations and assert v2 HTTP benchmark responses.

## Why

- Strengthens the Cucumber and benchmark harness against regressions in multi-input lookup behavior, metadata propagation, health wiring, and benchmark request mapping.

## Testing

- `make lint` - passed
- `make features` - passed
- `make benchmarks` - passed
