### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.506.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	git.jlel.se/jlelse/go-geouri v0.0.0-20210525190615-a9c1d50f42d6
 	github.com/IncSW/geoip2 v0.1.4
 	github.com/alexfalkowski/go-health/v2 v2.23.0
-	github.com/alexfalkowski/go-service/v2 v2.505.0
+	github.com/alexfalkowski/go-service/v2 v2.506.0
 	github.com/pariz/gountries v0.1.6
 	github.com/paulmach/orb v0.13.0
 	github.com/tidwall/rtree v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.23.0 h1:fYAMpjTneRsi4h8mrvGseTeErYJlh96LK4aMcKs52O0=
 github.com/alexfalkowski/go-health/v2 v2.23.0/go.mod h1:ypy+lqZpEh2HPNLqaDAv6wJBbxuouOZoPkkrtrMNXrA=
-github.com/alexfalkowski/go-service/v2 v2.505.0 h1:uw12YXiFhmIeV3lvYP/ed/vRGFvf5KtD86RyHuem4wU=
-github.com/alexfalkowski/go-service/v2 v2.505.0/go.mod h1:VatR3v/iEhAWbU662upiBtGYzsBVXIKR1mjFB54IkGE=
+github.com/alexfalkowski/go-service/v2 v2.506.0 h1:nBHpYO8lWozr/hyKUtjFxjC5ftUYCIcLKI2QahZHteU=
+github.com/alexfalkowski/go-service/v2 v2.506.0/go.mod h1:VatR3v/iEhAWbU662upiBtGYzsBVXIKR1mjFB54IkGE=
 github.com/alexfalkowski/go-sync v1.21.0 h1:Aydt3mB0FwmaRPjDsO4ZHJIa0HdueTwRt0i4NQtNvsA=
 github.com/alexfalkowski/go-sync v1.21.0/go.mod h1:J2yBCIWJ1YAWqAJ94Bt2xroR2rOWlSyRBGqqNJDmLBw=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -40,11 +40,15 @@ GEM
     deep_merge (1.2.2)
     diff-lcs (1.6.2)
     domain_name (0.6.20240107)
+    ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     get_process_mem (1.0.0)
       bigdecimal (>= 2.0)
       ffi (~> 1.0)
+    google-protobuf (4.35.0-aarch64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
     google-protobuf (4.35.0-x86_64-darwin)
       bigdecimal
       rake (~> 13.3)
@@ -53,10 +57,13 @@ GEM
       rake (~> 13.3)
     googleapis-common-protos-types (1.23.0)
       google-protobuf (~> 4.26)
-    grpc (1.80.0-x86_64-darwin)
+    grpc (1.81.0-aarch64-linux-gnu)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
-    grpc (1.80.0-x86_64-linux-gnu)
+    grpc (1.81.0-x86_64-darwin)
+      google-protobuf (>= 3.25, < 5.0)
+      googleapis-common-protos-types (~> 1.0)
+    grpc (1.81.0-x86_64-linux-gnu)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
     http-accept (1.7.0)
@@ -176,6 +183,7 @@ GEM
     unicode-emoji (4.2.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-darwin-21
   x86_64-darwin-23
   x86_64-linux


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.506.0
