### PR TITLE
docs(readme): clarify startup and api examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,21 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/alexfalkowski/standort/v2.svg)](https://pkg.go.dev/github.com/alexfalkowski/standort/v2)
 [![Stability: Active](https://masterminds.github.io/stability/active.svg)](https://masterminds.github.io/stability/active.html)
 
-# Standort
+# 📍 Standort
 
 Standort is a Go service that provides location-based information (country + continent) from:
 
 - an **IP address** (GeoIP2 database lookup), and/or
 - a **latitude/longitude point** (point-in-polygon lookup over embedded GeoJSON).
 
-It exposes **two API versions (v1 and v2)** over **gRPC** and **HTTP**.
+It exposes **two API versions (v1 and v2)** over **gRPC** and **HTTP**. It is useful when an application needs a small service boundary for country/continent enrichment without calling an external provider at request time.
+
+> [!NOTE]
+> Standort ships its lookup data as embedded assets, so runtime responses are determined by the GeoIP2 database and GeoJSON files committed under `assets/`.
 
 ---
 
-## What “location” means
+## 🧭 What “location” means
 
 Standort returns:
 
@@ -28,18 +31,21 @@ Lookups are performed using embedded assets:
 - `assets/geoip2.mmdb`: IP → country code (GeoIP2)
 - `assets/earth.geojson`: lat/lng → country + continent name (GeoJSON polygons), indexed with an R-tree
 
+> [!CAUTION]
+> Location accuracy is only as current as the embedded datasets. Update the assets and rebuild the service when lookup freshness matters.
+
 ---
 
-## API versions
+## 🔌 API versions
 
-### v1
+### 1️⃣ v1
 
 v1 has separate RPCs for IP-based lookup and lat/lng-based lookup.
 
 - `GetLocationByIP`
 - `GetLocationByLatLng`
 
-### v2
+### 2️⃣ v2
 
 v2 combines both inputs into a single RPC:
 
@@ -52,17 +58,22 @@ v2 supports passing inputs either directly in the request *or* via request metad
 
 If a lookup fails, v2 records error details into response `meta` attributes where possible, and only returns “not found” when neither IP nor GEO yields a location.
 
+> [!WARNING]
+> Treat forwarded IP metadata as trusted only after your proxy or gateway has normalized it. Standort reads the metadata supplied by the transport layer; it does not decide whether a forwarded client IP is trustworthy.
+
 ---
 
-## Quickstart (development)
+## 🚀 Quickstart (development)
 
-### Prerequisites
+### ✅ Prerequisites
 
-- Go (see `go.mod` for the required version)
+- Go `1.26.0` (see `go.mod`)
 - Git submodules (this repo relies on a `bin/` submodule)
 - Ruby (used by the feature/benchmark harness under `test/`)
 
-### Bootstrap
+Optional tools used by specific targets include `air`, `buf`, `gotestsum`, `govulncheck`, `trivy`, and `hadolint`.
+
+### 🧰 Bootstrap
 
 Initialize submodules and vendor dependencies:
 
@@ -72,11 +83,10 @@ git submodule update --init
 make dep
 ```
 
-Notes:
-- Many `make` targets run with `-mod vendor`.
-- If you see “inconsistent vendoring” errors, re-run `make dep`.
+> [!IMPORTANT]
+> Most workflow commands include make fragments from the `bin/` submodule, and many Go targets run with `-mod vendor`. If `bin/` is missing or Go reports “inconsistent vendoring,” run the bootstrap commands above again.
 
-### Build
+### 🏗️ Build
 
 Build the server binary:
 
@@ -84,14 +94,14 @@ Build the server binary:
 make build
 ```
 
-### Run locally (dev config)
+### 🖥️ Run locally (dev config)
 
 The repository includes a dev config at `test/.config/server.yml` with default addresses:
 
 - HTTP: `:11000`
 - gRPC: `:12000`
 
-#### Option A: dev mode (requires `air`)
+#### ♻️ Option A: dev mode (requires `air`)
 
 ```sh
 make dev
@@ -99,39 +109,44 @@ make dev
 
 This runs `air` to rebuild and restart using the dev config.
 
-#### Option B: run the binary directly
+#### ▶️ Option B: run the binary directly
 
 If you’ve built the binary (via `make build`), run:
 
 ```sh
-./standort server -i file:test/.config/server.yml
+./standort server -config file:test/.config/server.yml
 ```
 
 ---
 
-## Health endpoints
+## ❤️ Health endpoints
 
 When running with the dev config, the health HTTP observer endpoints are:
 
-- `GET http://localhost:11000/healthz`
-- `GET http://localhost:11000/livez`
-- `GET http://localhost:11000/readyz`
+- `GET http://localhost:11000/standort/healthz`
+- `GET http://localhost:11000/standort/livez`
+- `GET http://localhost:11000/standort/readyz`
+- `GET http://localhost:11000/standort/metrics`
 
-(Exact behavior depends on the go-service/go-health wiring.)
+> [!NOTE]
+> go-service prefixes operational HTTP routes with the service name. The dev and test harness service name is `standort`.
+
+The `healthz` endpoint uses go-health's online checker. The `livez` and `readyz` endpoints are local noop observers. The `metrics` endpoint is available with the dev config because it sets `telemetry.metrics.kind: prometheus`.
 
 ---
 
-## API usage examples
+## 📡 API usage examples
 
-The service is gRPC-first; HTTP is wired by routing HTTP requests to the gRPC handlers. Exact HTTP routes and encoding are provided by the go-service RPC router.
+The service is gRPC-first; HTTP is wired by routing HTTP requests to the gRPC handlers through go-service RPC routing.
 
-### gRPC examples
+> [!TIP]
+> Use `-plaintext` with `grpcurl` for the local dev config unless you have configured TLS.
+
+### 🧪 gRPC examples
 
 You can use `grpcurl` against the dev gRPC address (`localhost:12000`).
 
-> Tip: you may need `-plaintext` for local development unless you’ve configured TLS.
-
-#### v1: lookup by IP
+#### 🌐 v1: lookup by IP
 
 ```sh
 grpcurl -plaintext \
@@ -140,7 +155,7 @@ grpcurl -plaintext \
   standort.v1.Service/GetLocationByIP
 ```
 
-#### v1: lookup by lat/lng
+#### 🗺️ v1: lookup by lat/lng
 
 ```sh
 grpcurl -plaintext \
@@ -149,7 +164,7 @@ grpcurl -plaintext \
   standort.v1.Service/GetLocationByLatLng
 ```
 
-#### v2: lookup with explicit IP
+#### 🌐 v2: lookup with explicit IP
 
 ```sh
 grpcurl -plaintext \
@@ -158,7 +173,7 @@ grpcurl -plaintext \
   standort.v2.Service/GetLocation
 ```
 
-#### v2: lookup with explicit point
+#### 🗺️ v2: lookup with explicit point
 
 ```sh
 grpcurl -plaintext \
@@ -167,7 +182,7 @@ grpcurl -plaintext \
   standort.v2.Service/GetLocation
 ```
 
-#### v2: lookup using metadata (headers)
+#### 🧾 v2: lookup using metadata (headers)
 
 v2 can fall back to metadata when request fields are omitted:
 
@@ -184,7 +199,7 @@ grpcurl -plaintext \
   standort.v2.Service/GetLocation
 ```
 
-Example with a forwarded IP (exact metadata key handling is framework-dependent, but commonly derived from HTTP `X-Forwarded-For` in the gateway/proxy layer):
+Example with a forwarded IP:
 
 ```sh
 grpcurl -plaintext \
@@ -194,31 +209,72 @@ grpcurl -plaintext \
   standort.v2.Service/GetLocation
 ```
 
-### HTTP examples
+### 🌍 HTTP examples
 
-HTTP runs on `localhost:11000` with the dev config.
+HTTP runs on `localhost:11000` with the dev config. The RPC router exposes POST routes using the generated gRPC full method names.
 
-Because HTTP routing is generated/wired via go-service RPC routing, the easiest accurate source of truth for HTTP paths is the service at runtime (logs) or the framework documentation/config. The mapping is based on the generated gRPC full method names:
+#### 🌐 v1: lookup by IP
 
-- v1:
-  - `standort.v1.Service/GetLocationByIP`
-  - `standort.v1.Service/GetLocationByLatLng`
-- v2:
-  - `standort.v2.Service/GetLocation`
+```sh
+curl -sS \
+  -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"ip":"8.8.8.8"}' \
+  http://localhost:11000/standort.v1.Service/GetLocationByIP
+```
 
-If you want fully concrete `curl` examples for the HTTP endpoints (paths, methods, and JSON shapes), run the server and inspect the registered routes (or share the route output/logs), and I’ll add them verbatim.
+#### 🗺️ v1: lookup by lat/lng
+
+```sh
+curl -sS \
+  -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"lat":52.5200,"lng":13.4050}' \
+  http://localhost:11000/standort.v1.Service/GetLocationByLatLng
+```
+
+#### 🌐 v2: lookup with explicit IP
+
+```sh
+curl -sS \
+  -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"ip":"8.8.8.8"}' \
+  http://localhost:11000/standort.v2.Service/GetLocation
+```
+
+#### 🗺️ v2: lookup with explicit point
+
+```sh
+curl -sS \
+  -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"point":{"lat":52.5200,"lng":13.4050}}' \
+  http://localhost:11000/standort.v2.Service/GetLocation
+```
+
+#### 🧾 v2: lookup using metadata headers
+
+```sh
+curl -sS \
+  -X POST \
+  -H 'Content-Type: application/json' \
+  -H 'Geolocation: geo:52.5200,13.4050' \
+  -d '{}' \
+  http://localhost:11000/standort.v2.Service/GetLocation
+```
 
 ---
 
-## Development workflow
+## 🛠️ Development workflow
 
-### Format
+### 🎨 Format
 
 ```sh
 make format
 ```
 
-### Lint
+### 🔎 Lint
 
 ```sh
 make lint
@@ -230,29 +286,46 @@ To apply automatic fixes where available:
 make fix-lint
 ```
 
-### Unit/spec tests (Go)
+### 🧪 Unit/spec tests (Go)
 
 ```sh
 make specs
 ```
 
-Note: `make specs` uses `gotestsum` directly. Install it if you don’t already have it.
+`make specs` uses `gotestsum` directly. Install it if you don’t already have it.
 
-### Feature tests (Ruby harness)
+### 🧩 Feature tests (Ruby harness)
 
 ```sh
 make features
 ```
 
-### Benchmarks (Ruby harness)
+### ⏱️ Benchmarks (Ruby harness)
 
 ```sh
 make benchmarks
 ```
 
+### 🧯 Security checks
+
+```sh
+make sec
+make trivy-repo
+```
+
+### ✅ CI parity
+
+CircleCI initializes submodules, vendors dependencies, then runs linting, protobuf breaking checks, security checks, feature tests, benchmarks, analysis, coverage, and Codecov upload. For a focused local pre-push check, start with:
+
+```sh
+make dep
+make lint
+make specs
+```
+
 ---
 
-## Protobuf / API generation
+## 🧬 Protobuf / API generation
 
 Protos live under `api/standort/v1` and `api/standort/v2`.
 
@@ -270,9 +343,12 @@ Breaking-change check:
 make proto-breaking
 ```
 
+> [!CAUTION]
+> Do not hand-edit generated protobuf or gRPC files. Change the `.proto` files and run `make proto-generate`.
+
 ---
 
-## Repository layout (high level)
+## 🗂️ Repository layout (high level)
 
 - `main.go`: CLI entrypoint; registers the `server` command.
 - `internal/cmd`: DI composition and command wiring.
@@ -287,6 +363,12 @@ make proto-breaking
 
 ---
 
-## Changelog
+## 🆘 Support and maintenance
+
+Use the GitHub issue tracker for bug reports, documentation fixes, and feature requests. Maintainers should keep README command examples aligned with `Makefile`, `.circleci/config.yml`, and the generated API definitions under `api/`.
+
+---
+
+## 📝 Changelog
 
 See `CHANGELOG.md`.


### PR DESCRIPTION
## What

- Updated the README navigation with emoji-prefixed headings and GitHub callouts for notes, tips, important setup details, warnings, and cautions.
- Corrected local startup and operational endpoint examples to match the current `-config` flag and service-prefixed health and metrics routes.
- Replaced the vague HTTP guidance with concrete gRPC and HTTP request examples, and added concise workflow, security, CI parity, and maintenance guidance.

## Why

- The README should be copy-paste reliable for local development and API exploration.
- The previous direct-run flag and health endpoint examples could send users down failing paths, while the HTTP section withheld routes that are already defined in the repository.
- Clearer callouts make setup requirements, metadata trust boundaries, dataset freshness, and generated-file handling easier to scan.

## Testing

- `git diff --check` - passed
- `rg -n "^#+ [^[:space:]]+ .+" README.md` - passed
- `rg -n "\\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\\]|server -config|/standort/(healthz|livez|readyz|metrics)|standort\\.v[12]\\.Service" README.md` - passed
- No markdown-specific lint target exists in this repository; validation was limited to README structure, references, and whitespace checks.

AI-assisted-by: [Codex](https://openai.com/codex/)
