### PR TITLE
docs(readme): clarify api metadata and workflow guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,9 +25,9 @@ This repository is a Go service called **standort** (location-based information)
 
 ### Prerequisites (observed)
 
-- Go (see `go.mod` → `go 1.25.0`)
+- Go (see `go.mod`)
 - Git submodules with GitHub SSH access (the repo relies on a `bin/` submodule; see `.gitmodules`)
-- Ruby (used for the Ruby test/benchmark harness under `test/`)
+- Ruby with Bundler (used for the Ruby test/benchmark harness under `test/`)
 
 Tools referenced by `make` targets (only run if installed): `buf`, `gotestsum`, `govulncheck`, `air`, `hadolint`, `trivy`, `codecovcli`, `mkcert`, `goda`, `dot`, `gsa`, `scc`.
 
@@ -72,13 +72,13 @@ make dev
 
 Observed from `bin/build/make/grpc.mak:216-218`:
 - Runs `air --build.cmd "make dep build"`.
-- Runs the binary as `./standort server -i file:test/.config/server.yml`.
+- Runs the binary as `./standort server -config file:test/.config/server.yml`.
 
 Run the built binary directly:
 
 ```sh
 make build
-./standort server -i file:test/.config/server.yml
+./standort server -config file:test/.config/server.yml
 ```
 
 The dev config file `test/.config/server.yml` configures addresses:
@@ -150,6 +150,14 @@ make proto-breaking
 
 - Uses `buf breaking --against 'https://github.com/alexfalkowski/$(NAME).git#branch=master,subdir=api'` (see `api/Makefile` → `bin/build/make/buf.mak:27-29`).
 
+Generated-output freshness check:
+
+```sh
+make proto-stale
+```
+
+- Runs `buf generate` and fails if generated protobuf outputs differ from the committed files.
+
 ### Security / containers (optional)
 
 ```sh
@@ -220,7 +228,7 @@ make trivy-image platform=amd64
 ## CI signals (CircleCI)
 
 CircleCI runs (see `.circleci/config.yml`):
-- `make dep`, `make lint`, `make proto-breaking`, `make sec`, `make trivy-repo`, `make features`, `make benchmarks`, `make analyse`, `make coverage`, `make codecov-upload`.
+- `make dep`, `make lint`, `make proto-breaking`, `make proto-stale`, `make sec`, `make trivy-repo`, `make features`, `make benchmarks`, `make analyse`, `make coverage`, `make codecov-upload`.
 
 If you’re trying to match CI locally, start with:
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ v2 supports passing inputs either directly in the request *or* via request metad
 
 If a lookup fails, v2 records error details into response `meta` attributes where possible, and only returns “not found” when neither IP nor GEO yields a location.
 
+v2 response fields are independent:
+
+- `ip` is populated when the IP lookup succeeds.
+- `geo` is populated when the point lookup succeeds.
+- both fields are populated when both inputs succeed.
+- on partial success, the successful field is returned and `meta` includes one of `locationIpError`, `locationLatLngError`, or `locationPointError`.
+
 > [!WARNING]
 > Treat forwarded IP metadata as trusted only after your proxy or gateway has normalized it. Standort reads the metadata supplied by the transport layer; it does not decide whether a forwarded client IP is trustworthy.
 
@@ -67,9 +74,9 @@ If a lookup fails, v2 records error details into response `meta` attributes wher
 
 ### ✅ Prerequisites
 
-- Go `1.26.0` (see `go.mod`)
+- Go (see `go.mod`)
 - Git submodules with GitHub SSH access (this repo relies on a `bin/` submodule)
-- Ruby (used by the feature/benchmark harness under `test/`)
+- Ruby with Bundler (used by the feature/benchmark harness under `test/`)
 
 Optional tools used by specific targets include `air`, `buf`, `gotestsum`, `govulncheck`, `trivy`, and `hadolint`.
 
@@ -316,7 +323,7 @@ make trivy-repo
 
 ### ✅ CI parity
 
-CircleCI initializes submodules, vendors dependencies, then runs linting, protobuf breaking checks, security checks, feature tests, benchmarks, analysis, coverage, and Codecov upload. For a focused local pre-push check, start with:
+CircleCI initializes submodules, vendors dependencies, then runs linting, protobuf breaking and generated-output stale checks, security checks, feature tests, benchmarks, analysis, coverage, and Codecov upload. For a focused local pre-push check, start with:
 
 ```sh
 make dep
@@ -344,6 +351,12 @@ Breaking-change check:
 make proto-breaking
 ```
 
+Generated-output freshness check:
+
+```sh
+make proto-stale
+```
+
 > [!CAUTION]
 > Do not hand-edit generated protobuf or gRPC files. Change the `.proto` files and run `make proto-generate`.
 
@@ -367,9 +380,3 @@ make proto-breaking
 ## 🆘 Support and maintenance
 
 Use the GitHub issue tracker for bug reports, documentation fixes, and feature requests. Maintainers should keep README command examples aligned with `Makefile`, `.circleci/config.yml`, and the generated API definitions under `api/`.
-
----
-
-## 📝 Changelog
-
-See `CHANGELOG.md`.

--- a/api/standort/v1/service.pb.go
+++ b/api/standort/v1/service.pb.go
@@ -76,8 +76,9 @@ func (x *Location) GetContinent() string {
 
 // GetLocationByIPRequest for an IP address.
 type GetLocationByIPRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Ip            string                 `protobuf:"bytes,1,opt,name=ip,proto3" json:"ip,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// IP address to resolve.
+	Ip            string `protobuf:"bytes,1,opt,name=ip,proto3" json:"ip,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -121,9 +122,11 @@ func (x *GetLocationByIPRequest) GetIp() string {
 
 // GetLocationByIPResponse for an IP address.
 type GetLocationByIPResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Meta          map[string]string      `protobuf:"bytes,1,rep,name=meta,proto3" json:"meta,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	Location      *Location              `protobuf:"bytes,2,opt,name=location,proto3" json:"location,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Meta contains request metadata returned to the caller, such as requestId.
+	Meta map[string]string `protobuf:"bytes,1,rep,name=meta,proto3" json:"meta,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// Location resolved from the IP address.
+	Location      *Location `protobuf:"bytes,2,opt,name=location,proto3" json:"location,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -174,9 +177,11 @@ func (x *GetLocationByIPResponse) GetLocation() *Location {
 
 // GetLocationByLatLngRequest for a latitude and longitude.
 type GetLocationByLatLngRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Lat           float64                `protobuf:"fixed64,1,opt,name=lat,proto3" json:"lat,omitempty"`
-	Lng           float64                `protobuf:"fixed64,2,opt,name=lng,proto3" json:"lng,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Latitude in degrees.
+	Lat float64 `protobuf:"fixed64,1,opt,name=lat,proto3" json:"lat,omitempty"`
+	// Longitude in degrees.
+	Lng           float64 `protobuf:"fixed64,2,opt,name=lng,proto3" json:"lng,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -227,9 +232,11 @@ func (x *GetLocationByLatLngRequest) GetLng() float64 {
 
 // GetLocationByLatLngResponse for a latitude and longitude.
 type GetLocationByLatLngResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Meta          map[string]string      `protobuf:"bytes,2,rep,name=meta,proto3" json:"meta,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	Location      *Location              `protobuf:"bytes,1,opt,name=location,proto3" json:"location,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Meta contains request metadata returned to the caller, such as requestId.
+	Meta map[string]string `protobuf:"bytes,2,rep,name=meta,proto3" json:"meta,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// Location resolved from the latitude/longitude point.
+	Location      *Location `protobuf:"bytes,1,opt,name=location,proto3" json:"location,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/api/standort/v1/service.proto
+++ b/api/standort/v1/service.proto
@@ -13,24 +13,34 @@ message Location {
 
 // GetLocationByIPRequest for an IP address.
 message GetLocationByIPRequest {
+  // IP address to resolve.
   string ip = 1;
 }
 
 // GetLocationByIPResponse for an IP address.
 message GetLocationByIPResponse {
+  // Meta contains request metadata returned to the caller, such as requestId.
   map<string, string> meta = 1;
+
+  // Location resolved from the IP address.
   Location location = 2;
 }
 
 // GetLocationByLatLngRequest for a latitude and longitude.
 message GetLocationByLatLngRequest {
+  // Latitude in degrees.
   double lat = 1;
+
+  // Longitude in degrees.
   double lng = 2;
 }
 
 // GetLocationByLatLngResponse for a latitude and longitude.
 message GetLocationByLatLngResponse {
+  // Meta contains request metadata returned to the caller, such as requestId.
   map<string, string> meta = 2;
+
+  // Location resolved from the latitude/longitude point.
   Location location = 1;
 }
 

--- a/api/standort/v2/service.pb.go
+++ b/api/standort/v2/service.pb.go
@@ -23,9 +23,11 @@ const (
 
 // Location of the response.
 type Location struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Country       string                 `protobuf:"bytes,1,opt,name=country,proto3" json:"country,omitempty"`
-	Continent     string                 `protobuf:"bytes,2,opt,name=continent,proto3" json:"continent,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// ISO-3166 alpha-2 country code, such as US or DE.
+	Country string `protobuf:"bytes,1,opt,name=country,proto3" json:"country,omitempty"`
+	// Two-letter continent code, such as NA or EU.
+	Continent     string `protobuf:"bytes,2,opt,name=continent,proto3" json:"continent,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -76,9 +78,11 @@ func (x *Location) GetContinent() string {
 
 // Point for the request.
 type Point struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Lat           float64                `protobuf:"fixed64,1,opt,name=lat,proto3" json:"lat,omitempty"`
-	Lng           float64                `protobuf:"fixed64,2,opt,name=lng,proto3" json:"lng,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Latitude in degrees.
+	Lat float64 `protobuf:"fixed64,1,opt,name=lat,proto3" json:"lat,omitempty"`
+	// Longitude in degrees.
+	Lng           float64 `protobuf:"fixed64,2,opt,name=lng,proto3" json:"lng,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -129,9 +133,11 @@ func (x *Point) GetLng() float64 {
 
 // GetLocationRequest for getting the location.
 type GetLocationRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Ip            string                 `protobuf:"bytes,1,opt,name=ip,proto3" json:"ip,omitempty"`
-	Point         *Point                 `protobuf:"bytes,2,opt,name=point,proto3" json:"point,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// IP address to resolve. If empty, the server may use request metadata such as X-Forwarded-For.
+	Ip string `protobuf:"bytes,1,opt,name=ip,proto3" json:"ip,omitempty"`
+	// Geographic point to resolve. If omitted, the server may use a Geolocation metadata header.
+	Point         *Point `protobuf:"bytes,2,opt,name=point,proto3" json:"point,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -182,10 +188,14 @@ func (x *GetLocationRequest) GetPoint() *Point {
 
 // GetLocationResponse for getting the location.
 type GetLocationResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Meta          map[string]string      `protobuf:"bytes,1,rep,name=meta,proto3" json:"meta,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	Ip            *Location              `protobuf:"bytes,2,opt,name=ip,proto3" json:"ip,omitempty"`
-	Geo           *Location              `protobuf:"bytes,3,opt,name=geo,proto3" json:"geo,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Meta contains request metadata and partial-failure details. Partial lookup
+	// errors use locationIpError, locationLatLngError, or locationPointError.
+	Meta map[string]string `protobuf:"bytes,1,rep,name=meta,proto3" json:"meta,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// IP is populated when the IP lookup succeeds.
+	Ip *Location `protobuf:"bytes,2,opt,name=ip,proto3" json:"ip,omitempty"`
+	// Geo is populated when the point lookup succeeds.
+	Geo           *Location `protobuf:"bytes,3,opt,name=geo,proto3" json:"geo,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/api/standort/v2/service.proto
+++ b/api/standort/v2/service.proto
@@ -7,26 +7,41 @@ option ruby_package = "Standort::V2";
 
 // Location of the response.
 message Location {
+  // ISO-3166 alpha-2 country code, such as US or DE.
   string country = 1;
+
+  // Two-letter continent code, such as NA or EU.
   string continent = 2;
 }
 
 // Point for the request.
 message Point {
+  // Latitude in degrees.
   double lat = 1;
+
+  // Longitude in degrees.
   double lng = 2;
 }
 
 // GetLocationRequest for getting the location.
 message GetLocationRequest {
+  // IP address to resolve. If empty, the server may use request metadata such as X-Forwarded-For.
   string ip = 1;
+
+  // Geographic point to resolve. If omitted, the server may use a Geolocation metadata header.
   Point point = 2;
 }
 
 // GetLocationResponse for getting the location.
 message GetLocationResponse {
+  // Meta contains request metadata and partial-failure details. Partial lookup
+  // errors use locationIpError, locationLatLngError, or locationPointError.
   map<string, string> meta = 1;
+
+  // IP is populated when the IP lookup succeeds.
   Location ip = 2;
+
+  // Geo is populated when the point lookup succeeds.
   Location geo = 3;
 }
 

--- a/assets/assets.go
+++ b/assets/assets.go
@@ -18,7 +18,7 @@ var fs embed.FS
 //
 // Consumers can use the returned `embed.FS` with standard `fs` APIs such as
 // `fs.ReadFile` to load embedded asset files by name (for example,
-// `fs.ReadFile("earth.geojson")`).
+// `fs.ReadFile(NewFS(), "earth.geojson")`).
 func NewFS() embed.FS {
 	return fs
 }

--- a/internal/location/continent/doc.go
+++ b/internal/location/continent/doc.go
@@ -11,6 +11,7 @@
 // two-letter code:
 //
 //   - "Africa"        → "AF"
+//   - "Antarctica"    → "AN"
 //   - "Asia"          → "AS"
 //   - "Europe"        → "EU"
 //   - "North America" → "NA"

--- a/internal/location/orb/provider/rtree/rtree.go
+++ b/internal/location/orb/provider/rtree/rtree.go
@@ -73,10 +73,12 @@ func (p *Provider) Search(_ context.Context, lat, lng float64) (string, string, 
 	return data.Country, data.Continent, nil
 }
 
-// populateTree reads `earth.geojson` from the embedded filesystem and inserts each
-// feature's geometry into the R-tree.
+// populateTree reads `earth.geojson` from the embedded filesystem and inserts
+// features that include a valid country code and supported continent.
 //
 // The inserted bounding boxes are derived from the feature geometry bounds.
+// Features are skipped unless they have a two-character `iso_a2` or `iso_a2_eh`
+// property and a `continent` value present in `continent.Codes`.
 func populateTree(tree *rtree.Generic[*Node], fs embed.FS) {
 	data, err := fs.ReadFile("earth.geojson")
 	runtime.Must(err)

--- a/test/lib/standort.rb
+++ b/test/lib/standort.rb
@@ -47,7 +47,7 @@ module Standort
     # The underlying configuration loader is provided by `Nonnative` and reads
     # the YAML config file at `.config/server.yml` *relative to the `test/` directory*.
     #
-    # @return [Hash] The configuration as returned by `Nonnative::ConfigurationFile.load`.
+    # @return [Object] The configuration object returned by `Nonnative::ConfigurationFile.load`.
     #
     def config
       @config ||= Nonnative::ConfigurationFile.load('.config/server.yml')


### PR DESCRIPTION
## What

- Clarify the v2 response contract for independent IP and geo results, partial success, and metadata diagnostics.
- Document v1 response metadata propagation and regenerate protobuf Go outputs from the updated proto comments.
- Refresh setup and CI guidance for Bundler, the current server config flag, proto stale checks, and remove the missing changelog reference.
- Correct small GoDoc and RDoc drift around embedded asset reads, continent mappings, GeoJSON indexing filters, and Ruby harness config access.

## Why

- API consumers and maintainers should not need feature tests or private implementation comments to understand response metadata, partial lookup behavior, or required local workflow tools.
- Keeping generated protobuf outputs and contributor docs aligned with current behavior reduces stale-doc and stale-generation review churn.

## Testing

- `make lint` - passed
- `make specs` - passed
- `make proto-stale` - passed after staging the intended changes, which lets the target verify that `buf generate` creates no additional unstaged output

AI-assisted-by: [Codex](https://openai.com/codex/)
