### PR TITLE
docs(readme): clarify lookup and probe contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ v2 response fields are independent:
 - both fields are populated when both inputs succeed.
 - on partial success, the successful field is returned and `meta` includes one of `locationIpError`, `locationLatLngError`, or `locationPointError`.
 
+Lookup failures return gRPC `NotFound`; the HTTP RPC router exposes the same lookup miss as HTTP `404`. v2 partial success is still a successful response, with the failed lookup recorded in `meta`.
+
 > [!WARNING]
 > Treat forwarded IP metadata as trusted only after your proxy or gateway has normalized it. Standort reads the metadata supplied by the transport layer; it does not decide whether a forwarded client IP is trustworthy.
 
@@ -140,6 +142,13 @@ When running with the dev config, the health HTTP observer endpoints are:
 > go-service prefixes operational HTTP routes with the service name. The dev and test harness service name is `standort`.
 
 The `healthz` endpoint uses go-health's online checker. The `livez` and `readyz` endpoints are local noop observers. The `metrics` endpoint is available with the dev config because it sets `telemetry.metrics.kind: prometheus`.
+
+Use `livez` or `readyz` for local process probes that must not depend on public egress. The `healthz` endpoint is an online check and is expected to report unhealthy when the process cannot reach the public internet.
+
+The gRPC health service registers these service names:
+
+- `standort.v1.Service`
+- `standort.v2.Service`
 
 ---
 
@@ -272,6 +281,17 @@ curl -sS \
   http://localhost:11000/standort.v2.Service/GetLocation
 ```
 
+Example with a forwarded IP:
+
+```sh
+curl -sS \
+  -X POST \
+  -H 'Content-Type: application/json' \
+  -H 'X-Forwarded-For: 8.8.8.8' \
+  -d '{}' \
+  http://localhost:11000/standort.v2.Service/GetLocation
+```
+
 ---
 
 ## 🛠️ Development workflow
@@ -308,11 +328,15 @@ make specs
 make features
 ```
 
+The Ruby harness is configured by `test/nonnative.yml` and writes logs, coverage, and report artifacts under `test/reports/`.
+
 ### ⏱️ Benchmarks (Ruby harness)
 
 ```sh
 make benchmarks
 ```
+
+Benchmark runs use the same harness configuration and report directory as feature tests.
 
 ### 🧯 Security checks
 
@@ -345,11 +369,15 @@ make proto-format
 make proto-generate
 ```
 
+`buf generate` writes Go protobuf/gRPC files into this repository and Ruby protobuf/gRPC files under `test/lib`. When a `.proto` file is renamed or deleted, remove any orphaned generated Go and Ruby outputs in the same change.
+
 Breaking-change check:
 
 ```sh
 make proto-breaking
 ```
+
+`make proto-breaking` compares `api/` with the `master` branch on GitHub and requires network access to that remote baseline.
 
 Generated-output freshness check:
 

--- a/api/standort/v1/service.pb.go
+++ b/api/standort/v1/service.pb.go
@@ -178,9 +178,9 @@ func (x *GetLocationByIPResponse) GetLocation() *Location {
 // GetLocationByLatLngRequest for a latitude and longitude.
 type GetLocationByLatLngRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Latitude in degrees.
+	// Latitude in degrees. Must be finite and in the range [-90, 90].
 	Lat float64 `protobuf:"fixed64,1,opt,name=lat,proto3" json:"lat,omitempty"`
-	// Longitude in degrees.
+	// Longitude in degrees. Must be finite and in the range [-180, 180].
 	Lng           float64 `protobuf:"fixed64,2,opt,name=lng,proto3" json:"lng,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/api/standort/v1/service.proto
+++ b/api/standort/v1/service.proto
@@ -28,10 +28,10 @@ message GetLocationByIPResponse {
 
 // GetLocationByLatLngRequest for a latitude and longitude.
 message GetLocationByLatLngRequest {
-  // Latitude in degrees.
+  // Latitude in degrees. Must be finite and in the range [-90, 90].
   double lat = 1;
 
-  // Longitude in degrees.
+  // Longitude in degrees. Must be finite and in the range [-180, 180].
   double lng = 2;
 }
 
@@ -46,9 +46,11 @@ message GetLocationByLatLngResponse {
 
 // Service allows to get locations by different filters.
 service Service {
-  // GetLocationByIP for an IP address.
+  // GetLocationByIP for an IP address. Returns gRPC NotFound when the IP
+  // address cannot be resolved.
   rpc GetLocationByIP(GetLocationByIPRequest) returns (GetLocationByIPResponse) {}
 
-  // GetLocationByLatLng for a latitude and longitude.
+  // GetLocationByLatLng for a latitude and longitude. Returns gRPC NotFound
+  // when the point is invalid or cannot be resolved.
   rpc GetLocationByLatLng(GetLocationByLatLngRequest) returns (GetLocationByLatLngResponse) {}
 }

--- a/api/standort/v1/service_grpc.pb.go
+++ b/api/standort/v1/service_grpc.pb.go
@@ -29,9 +29,11 @@ const (
 //
 // Service allows to get locations by different filters.
 type ServiceClient interface {
-	// GetLocationByIP for an IP address.
+	// GetLocationByIP for an IP address. Returns gRPC NotFound when the IP
+	// address cannot be resolved.
 	GetLocationByIP(ctx context.Context, in *GetLocationByIPRequest, opts ...grpc.CallOption) (*GetLocationByIPResponse, error)
-	// GetLocationByLatLng for a latitude and longitude.
+	// GetLocationByLatLng for a latitude and longitude. Returns gRPC NotFound
+	// when the point is invalid or cannot be resolved.
 	GetLocationByLatLng(ctx context.Context, in *GetLocationByLatLngRequest, opts ...grpc.CallOption) (*GetLocationByLatLngResponse, error)
 }
 
@@ -69,9 +71,11 @@ func (c *serviceClient) GetLocationByLatLng(ctx context.Context, in *GetLocation
 //
 // Service allows to get locations by different filters.
 type ServiceServer interface {
-	// GetLocationByIP for an IP address.
+	// GetLocationByIP for an IP address. Returns gRPC NotFound when the IP
+	// address cannot be resolved.
 	GetLocationByIP(context.Context, *GetLocationByIPRequest) (*GetLocationByIPResponse, error)
-	// GetLocationByLatLng for a latitude and longitude.
+	// GetLocationByLatLng for a latitude and longitude. Returns gRPC NotFound
+	// when the point is invalid or cannot be resolved.
 	GetLocationByLatLng(context.Context, *GetLocationByLatLngRequest) (*GetLocationByLatLngResponse, error)
 	mustEmbedUnimplementedServiceServer()
 }

--- a/api/standort/v2/service.pb.go
+++ b/api/standort/v2/service.pb.go
@@ -79,9 +79,9 @@ func (x *Location) GetContinent() string {
 // Point for the request.
 type Point struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Latitude in degrees.
+	// Latitude in degrees. Must be finite and in the range [-90, 90].
 	Lat float64 `protobuf:"fixed64,1,opt,name=lat,proto3" json:"lat,omitempty"`
-	// Longitude in degrees.
+	// Longitude in degrees. Must be finite and in the range [-180, 180].
 	Lng           float64 `protobuf:"fixed64,2,opt,name=lng,proto3" json:"lng,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/api/standort/v2/service.proto
+++ b/api/standort/v2/service.proto
@@ -16,10 +16,10 @@ message Location {
 
 // Point for the request.
 message Point {
-  // Latitude in degrees.
+  // Latitude in degrees. Must be finite and in the range [-90, 90].
   double lat = 1;
 
-  // Longitude in degrees.
+  // Longitude in degrees. Must be finite and in the range [-180, 180].
   double lng = 2;
 }
 
@@ -47,6 +47,8 @@ message GetLocationResponse {
 
 // Service allows to get location via multiple methods.
 service Service {
-  // GetLocation via multiple methods.
+  // GetLocation resolves an IP address and/or geographic point. If one lookup
+  // succeeds, the response is successful and failed lookup details are recorded
+  // in meta. Returns gRPC NotFound only when no lookup succeeds.
   rpc GetLocation(GetLocationRequest) returns (GetLocationResponse) {}
 }

--- a/api/standort/v2/service_grpc.pb.go
+++ b/api/standort/v2/service_grpc.pb.go
@@ -28,7 +28,9 @@ const (
 //
 // Service allows to get location via multiple methods.
 type ServiceClient interface {
-	// GetLocation via multiple methods.
+	// GetLocation resolves an IP address and/or geographic point. If one lookup
+	// succeeds, the response is successful and failed lookup details are recorded
+	// in meta. Returns gRPC NotFound only when no lookup succeeds.
 	GetLocation(ctx context.Context, in *GetLocationRequest, opts ...grpc.CallOption) (*GetLocationResponse, error)
 }
 
@@ -56,7 +58,9 @@ func (c *serviceClient) GetLocation(ctx context.Context, in *GetLocationRequest,
 //
 // Service allows to get location via multiple methods.
 type ServiceServer interface {
-	// GetLocation via multiple methods.
+	// GetLocation resolves an IP address and/or geographic point. If one lookup
+	// succeeds, the response is successful and failed lookup details are recorded
+	// in meta. Returns gRPC NotFound only when no lookup succeeds.
 	GetLocation(context.Context, *GetLocationRequest) (*GetLocationResponse, error)
 	mustEmbedUnimplementedServiceServer()
 }

--- a/assets/doc.go
+++ b/assets/doc.go
@@ -6,7 +6,9 @@
 // Embedded files
 //
 //   - earth.geojson: used to build the spatial index for point-in-polygon
-//     lookups (latitude/longitude → country/continent).
+//     lookups (latitude/longitude → country/continent). The R-tree provider
+//     indexes only features with a two-character `iso_a2` or `iso_a2_eh` country
+//     code and a supported `continent` value.
 //   - geoip2.mmdb: used to resolve IP addresses to ISO country codes.
 //
 // # Dependency injection

--- a/internal/api/location/location.go
+++ b/internal/api/location/location.go
@@ -40,7 +40,11 @@ type (
 
 	// Point is a latitude/longitude pair used for geolocation lookup.
 	//
-	// Latitude and longitude are expected to be in degrees.
+	// Latitude and longitude are expected to be finite values in degrees.
+	// Latitude must be in the range [-90, 90], and longitude must be in the
+	// range [-180, 180]. Invalid points follow the same error path as unresolved
+	// points: `Locate` records `locationLatLngError` on partial success or
+	// returns `ErrNotFound` when no lookup succeeds.
 	Point struct {
 		Lat float64
 		Lng float64

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,10 +10,10 @@ import (
 // It composes standort-specific configuration (for example `Health`) with the
 // shared go-service configuration via an embedded `*config.Config`.
 type Config struct {
-	// Health configures the health subsystem (checks, observers, durations/timeouts, etc.).
+	// Health configures the health subsystem and is required.
 	Health *health.Config `yaml:"health,omitempty" json:"health,omitempty" toml:"health,omitempty" validate:"required"`
 
-	// Config is the embedded go-service base configuration.
+	// Config is the required embedded go-service base configuration.
 	//
 	// The `yaml:",inline"` / `json:",inline"` / `toml:",inline"` tags make the
 	// embedded fields appear at the top level of the config file.

--- a/internal/health/config.go
+++ b/internal/health/config.go
@@ -4,7 +4,9 @@ import "github.com/alexfalkowski/go-service/v2/time"
 
 // Config configures the health subsystem.
 //
-// Both fields are parsed as durations (for example: "250ms", "5s", "1m").
+// Both fields are required to be positive durations and are parsed from values
+// such as "250ms", "5s", or "1m". A zero value does not disable health checks
+// and does not act as a default.
 //
 // The values are used by the health module when registering checks and
 // observers:
@@ -12,9 +14,9 @@ import "github.com/alexfalkowski/go-service/v2/time"
 //   - Duration: the interval between health check executions.
 //   - Timeout: the maximum amount of time a health check is allowed to run.
 type Config struct {
-	// Duration is the period between health check runs.
+	// Duration is the positive period between health check runs.
 	Duration time.Duration `yaml:"duration,omitempty" json:"duration,omitempty" toml:"duration,omitempty" validate:"gt=0"`
 
-	// Timeout is the maximum time allowed for a health check execution.
+	// Timeout is the positive maximum time allowed for a health check execution.
 	Timeout time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" toml:"timeout,omitempty" validate:"gt=0"`
 }

--- a/internal/location/orb/provider/rtree/doc.go
+++ b/internal/location/orb/provider/rtree/doc.go
@@ -4,4 +4,9 @@
 // first use the R-tree to find candidate geometries by bounding box, then run an
 // exact point-in-polygon check before returning the dataset's country code and
 // continent name.
+//
+// Only supported GeoJSON features are indexed. A feature must provide a
+// two-character `iso_a2` or `iso_a2_eh` country code and a `continent` value
+// known to `internal/location/continent.Codes`. Other features are skipped, so a
+// not-found result means no indexed supported geometry matched the point.
 package rtree

--- a/internal/location/orb/provider/rtree/rtree.go
+++ b/internal/location/orb/provider/rtree/rtree.go
@@ -12,7 +12,7 @@ import (
 	"github.com/tidwall/rtree"
 )
 
-// ErrNotFound is returned when no geometry in the R-tree contains the queried point.
+// ErrNotFound is returned when no indexed supported geometry contains the queried point.
 //
 // This error is intended to be treated as a sentinel "no match" condition by
 // callers, as opposed to a system failure (I/O, parsing, etc.).
@@ -34,6 +34,7 @@ func NewProvider(fs embed.FS) *Provider {
 //
 // The index is built from `earth.geojson`. Each node stores the geometry along
 // with ISO-3166 alpha-2 country codes and continent names as provided by the dataset.
+// Features that lack a supported country code or continent are not indexed.
 type Provider struct {
 	tree *rtree.Generic[*Node]
 }
@@ -47,7 +48,7 @@ type Provider struct {
 // Returns:
 //   - countryCode: ISO-3166 alpha-2 code from the dataset (e.g. "US")
 //   - continent: continent name from the dataset (e.g. "North America")
-//   - err: `ErrNotFound` when no geometry contains the point
+//   - err: `ErrNotFound` when no indexed supported geometry contains the point
 func (p *Provider) Search(_ context.Context, lat, lng float64) (string, string, error) {
 	var (
 		found bool

--- a/test/lib/standort/v1/service_services_pb.rb
+++ b/test/lib/standort/v1/service_services_pb.rb
@@ -16,9 +16,11 @@ module Standort
         self.unmarshal_class_method = :decode
         self.service_name = 'standort.v1.Service'
 
-        # GetLocationByIP for an IP address.
+        # GetLocationByIP for an IP address. Returns gRPC NotFound when the IP
+        # address cannot be resolved.
         rpc :GetLocationByIP, ::Standort::V1::GetLocationByIPRequest, ::Standort::V1::GetLocationByIPResponse
-        # GetLocationByLatLng for a latitude and longitude.
+        # GetLocationByLatLng for a latitude and longitude. Returns gRPC NotFound
+        # when the point is invalid or cannot be resolved.
         rpc :GetLocationByLatLng, ::Standort::V1::GetLocationByLatLngRequest, ::Standort::V1::GetLocationByLatLngResponse
       end
 

--- a/test/lib/standort/v2/service_services_pb.rb
+++ b/test/lib/standort/v2/service_services_pb.rb
@@ -16,7 +16,9 @@ module Standort
         self.unmarshal_class_method = :decode
         self.service_name = 'standort.v2.Service'
 
-        # GetLocation via multiple methods.
+        # GetLocation resolves an IP address and/or geographic point. If one lookup
+        # succeeds, the response is successful and failed lookup details are recorded
+        # in meta. Returns gRPC NotFound only when no lookup succeeds.
         rpc :GetLocation, ::Standort::V2::GetLocationRequest, ::Standort::V2::GetLocationResponse
       end
 


### PR DESCRIPTION
## What

- Document lookup failure behavior, v2 partial-success semantics, health probe expectations, gRPC health service names, HTTP forwarded-IP usage, feature/benchmark artifacts, and protobuf generation ownership in the README.
- Add API comments for coordinate ranges and gRPC NotFound behavior in the v1/v2 protobuf contracts, then regenerate Go and Ruby protobuf outputs.
- Clarify package comments for transport point validation, required health configuration, and GeoJSON feature indexing/not-found semantics.

## Why

- These notes close confirmed documentation gaps that forced API consumers, operators, and maintainers to inspect implementation code or feature specs to understand important service contracts.
- The generated-output notes make proto edits safer by documenting where Go and Ruby outputs are produced and when orphaned files need cleanup.

## Testing

- `make lint` - passed
- `make proto-stale` - passed
