### PR TITLE
docs(readme): clarify service maintenance contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,7 +167,8 @@ make build-docker platform=amd64
 make trivy-image platform=amd64
 ```
 
-- `make sec` runs `govulncheck -show verbose -test ./...` (see `bin/build/make/grpc.mak:201-207`).
+- `make sec` runs `govulncheck -show verbose -test ./...` and the Trivy repo scan (see `bin/build/make/grpc.mak:201-207`).
+- `make trivy-repo` runs only the Trivy repo scan.
 
 ## Repository layout (observed)
 
@@ -228,7 +229,7 @@ make trivy-image platform=amd64
 ## CI signals (CircleCI)
 
 CircleCI runs (see `.circleci/config.yml`):
-- `make dep`, `make lint`, `make proto-breaking`, `make proto-stale`, `make sec`, `make trivy-repo`, `make features`, `make benchmarks`, `make analyse`, `make coverage`, `make codecov-upload`.
+- `make dep`, `make lint`, `make proto-breaking`, `make proto-stale`, `make sec`, `make features`, `make benchmarks`, `make analyse`, `make coverage`, `make codecov-upload`.
 
 If you’re trying to match CI locally, start with:
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ Lookups are performed using embedded assets:
 > [!CAUTION]
 > Location accuracy is only as current as the embedded datasets. Update the assets and rebuild the service when lookup freshness matters.
 
+When replacing embedded lookup data, keep the filenames and formats unchanged:
+
+- `geoip2.mmdb` must remain a GeoIP2 country database compatible with the `github.com/IncSW/geoip2` reader.
+- `earth.geojson` must remain a GeoJSON feature collection whose indexed features have Polygon or MultiPolygon geometry, a two-character `iso_a2` or `iso_a2_eh` country code, and a supported `continent` value.
+
+Record the dataset source/provenance in the asset update change, then rebuild and run the feature harness so changed lookup results are visible in review.
+
 ---
 
 ## 🔌 API versions
@@ -126,6 +133,22 @@ If you’ve built the binary (via `make build`), run:
 ```sh
 ./standort server -config file:test/.config/server.yml
 ```
+
+---
+
+## 🔧 Configuration
+
+`standort server` reads a go-service configuration file from `-config` (or `-c`). The dev sample at `test/.config/server.yml` is the authoritative local example.
+
+Standort-owned configuration currently adds the required `health` section:
+
+```yaml
+health:
+  duration: 1s
+  timeout: 1s
+```
+
+Both values must be positive durations. The rest of the file is the embedded go-service configuration, inlined at the top level, including transport addresses/timeouts, limiter settings, logger, metrics, tracer, and ID settings.
 
 ---
 
@@ -330,6 +353,12 @@ make features
 
 The Ruby harness is configured by `test/nonnative.yml` and writes logs, coverage, and report artifacts under `test/reports/`.
 
+The harness starts and stops `../standort server` itself with `-config file:.config/server.yml` relative to `test/`, so leave ports `11000` and `12000` free before running it. To rerun a focused slice, pass paths relative to `test/`:
+
+```sh
+make features feature=features/v2/transport/grpc/api.feature tags=@grpc
+```
+
 ### ⏱️ Benchmarks (Ruby harness)
 
 ```sh
@@ -338,12 +367,20 @@ make benchmarks
 
 Benchmark runs use the same harness configuration and report directory as feature tests.
 
+Focused benchmark runs also use paths relative to `test/`:
+
+```sh
+make benchmarks feature=features/v2/transport/http/benchmark.feature
+```
+
 ### 🧯 Security checks
 
 ```sh
 make sec
 make trivy-repo
 ```
+
+`make sec` is the full local security wrapper: it runs `govulncheck -show verbose -test ./...` and the Trivy repository scan. Use `make trivy-repo` only when you want the narrower Trivy-only scan.
 
 ### ✅ CI parity
 
@@ -369,7 +406,7 @@ make proto-format
 make proto-generate
 ```
 
-`buf generate` writes Go protobuf/gRPC files into this repository and Ruby protobuf/gRPC files under `test/lib`. When a `.proto` file is renamed or deleted, remove any orphaned generated Go and Ruby outputs in the same change.
+`buf generate` writes Go protobuf/gRPC files into this repository and Ruby protobuf/gRPC files under `test/lib`. It uses Buf remote plugins, so `make proto-generate` and `make proto-stale` may need network access on first run or when the plugin cache is empty. When a `.proto` file is renamed or deleted, remove any orphaned generated Go and Ruby outputs in the same change.
 
 Breaking-change check:
 

--- a/api/standort/v1/service.pb.go
+++ b/api/standort/v1/service.pb.go
@@ -23,9 +23,11 @@ const (
 
 // Location of the response.
 type Location struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Country       string                 `protobuf:"bytes,1,opt,name=country,proto3" json:"country,omitempty"`
-	Continent     string                 `protobuf:"bytes,2,opt,name=continent,proto3" json:"continent,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// ISO-3166 alpha-2 country code, such as US or DE.
+	Country string `protobuf:"bytes,1,opt,name=country,proto3" json:"country,omitempty"`
+	// Two-letter continent code, such as NA or EU.
+	Continent     string `protobuf:"bytes,2,opt,name=continent,proto3" json:"continent,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/api/standort/v1/service.proto
+++ b/api/standort/v1/service.proto
@@ -7,7 +7,10 @@ option ruby_package = "Standort::V1";
 
 // Location of the response.
 message Location {
+  // ISO-3166 alpha-2 country code, such as US or DE.
   string country = 1;
+
+  // Two-letter continent code, such as NA or EU.
   string continent = 2;
 }
 

--- a/internal/location/continent/continent.go
+++ b/internal/location/continent/continent.go
@@ -17,6 +17,9 @@ package continent
 //
 // This map is used by the domain `internal/location` service to normalize provider
 // outputs into stable API codes.
+//
+// Treat Codes as read-only. Mutating it changes continent normalization for the
+// whole process.
 var Codes = map[string]string{
 	"Africa":        "AF",
 	"North America": "NA",

--- a/internal/location/orb/provider/rtree/doc.go
+++ b/internal/location/orb/provider/rtree/doc.go
@@ -5,8 +5,12 @@
 // exact point-in-polygon check before returning the dataset's country code and
 // continent name.
 //
-// Only supported GeoJSON features are indexed. A feature must provide a
-// two-character `iso_a2` or `iso_a2_eh` country code and a `continent` value
-// known to `internal/location/continent.Codes`. Other features are skipped, so a
-// not-found result means no indexed supported geometry matched the point.
+// Only supported GeoJSON features are indexed. A feature is supported when it
+// provides a two-character `iso_a2` or `iso_a2_eh` country code and a
+// `continent` value known to `internal/location/continent.Codes`. Features
+// without those properties are skipped, so a not-found result means no indexed
+// supported geometry matched the point.
+//
+// Indexed features are expected to use Polygon or MultiPolygon geometry. The
+// lookup path assumes that invariant when checking candidate nodes.
 package rtree

--- a/internal/location/orb/provider/rtree/node.go
+++ b/internal/location/orb/provider/rtree/node.go
@@ -13,7 +13,8 @@ import (
 //   - Country: ISO-3166 alpha-2 country code (e.g. "US").
 //   - Continent: continent name (e.g. "North America").
 //
-// Geometry is expected to be either an `orb.Polygon` or an `orb.MultiPolygon`.
+// Geometry must be either an `orb.Polygon` or an `orb.MultiPolygon`. The R-tree
+// lookup path assumes nodes preserve that invariant from `earth.geojson`.
 type Node struct {
 	Geometry  orb.Geometry
 	Country   string
@@ -24,7 +25,8 @@ type Node struct {
 // within this node's geometry.
 //
 // Inputs are expressed in degrees. Note that orb uses [x,y] ordering, which for
-// geographic coordinates corresponds to [lng,lat].
+// geographic coordinates corresponds to [lng,lat]. The method assumes
+// `Geometry` is an `orb.Polygon` or `orb.MultiPolygon`.
 func (n *Node) IsPointInGeometry(lat, lng float64) bool {
 	point := orb.Point{lng, lat}
 

--- a/test/features/v2/transport/http/api.feature
+++ b/test/features/v2/transport/http/api.feature
@@ -37,7 +37,7 @@ Feature: HTTP API
       | geoip2 | params |   154.6 |
       | geoip2 | params | 1.0.4.1 |
 
-    Examples: With ip2location headers
+    Examples: With geoip2 headers
       | source | method  | ip      |
       | geoip2 | headers | 0.0.0.0 |
       | geoip2 | headers | test    |


### PR DESCRIPTION
## What

- Clarify service maintenance contracts for embedded lookup assets, configuration, harness lifecycle, security validation, and protobuf generation.
- Document v1 response field formats in the protobuf contract and regenerate the generated Go protobuf output.
- Tighten GoDoc around R-tree geometry assumptions and process-wide continent code normalization, and correct a stale v2 HTTP feature provider label.

## Why

- These updates make the project easier to operate and maintain without reading private implementation details first.
- The docs now call out non-obvious constraints that affect lookup correctness, local feature/benchmark runs, generated API freshness, and security validation parity.

## Testing

- `make help` - passed
- `make proto-generate` - passed
- `make proto-lint` - passed
- `make proto-stale` - passed
- `make ruby-lint` - passed
- `make go-format` - passed
- `make lint` - passed after retrying a transient golangci-lint cache/concurrency error
- `git diff --check` - passed
- `make features feature=features/v2/transport/http/api.feature tags=@http` - passed
