### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.589.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	git.jlel.se/jlelse/go-geouri v0.0.0-20210525190615-a9c1d50f42d6
 	github.com/IncSW/geoip2 v0.1.4
 	github.com/alexfalkowski/go-health/v2 v2.29.0
-	github.com/alexfalkowski/go-service/v2 v2.587.0
+	github.com/alexfalkowski/go-service/v2 v2.589.0
 	github.com/pariz/gountries v0.1.6
 	github.com/paulmach/orb v0.13.0
 	github.com/tidwall/rtree v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.29.0 h1:ZXkXalGX4u5DZR6eZAySpXCb1UUAvq+ufD1Eq+kKUv8=
 github.com/alexfalkowski/go-health/v2 v2.29.0/go.mod h1:oIzLvkIhiXUbPSYQRW2Gezah+sW+ZEY9BcoOi/5Agxo=
-github.com/alexfalkowski/go-service/v2 v2.587.0 h1:Ts51NGo6a+oW/zxGO+cWRKR2pVcb+neHYVwAdvdpxYo=
-github.com/alexfalkowski/go-service/v2 v2.587.0/go.mod h1:bfFj9FyvRoviXOV3cyTBcFPoLFkmD3grvE1dhFzAeYQ=
+github.com/alexfalkowski/go-service/v2 v2.589.0 h1:LL6oU+TaWpYfE0VNDoB44luVVhgvO6bYm3UnnM1fOwk=
+github.com/alexfalkowski/go-service/v2 v2.589.0/go.mod h1:bfFj9FyvRoviXOV3cyTBcFPoLFkmD3grvE1dhFzAeYQ=
 github.com/alexfalkowski/go-sync v1.24.0 h1:CrV+LITc8C78v01u9ATGvIgipmNtJlZWGWW1znFsdjM=
 github.com/alexfalkowski/go-sync v1.24.0/go.mod h1:2vmRtpHHSoGPIiXJ7j3lm0GK2SI32XbYvvrjrZ+eo/k=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
     rspec-support (3.13.7)
     rspec-wait (1.0.2)
       rspec (>= 3.4)
-    rubocop (1.87.0)
+    rubocop (1.88.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.589.0
