### PR TITLE
test(feature): centralize harness request options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor
 dist
 .source-key
 ISSUES.md
+FEATURES.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,15 @@ This repository is a Go service called **standort** (location-based information)
   pipelines moving `latest` out of order. Reliable consumers should still pin
   versioned image tags, so do not report `latest` as the deployment contract
   unless versioned tags or documented pinning behavior are affected.
+- If a one-command local CI preflight target is needed, add it to the shared
+  `bin` Make fragments rather than as a service-local target here. Do not report
+  the absence of a root `verify`/`ci-checks` target as a feature gap by default.
+- The Ruby code under `test/` is a local feature/benchmark harness, not
+  production service code. Fixed localhost endpoints in `test/lib/**`,
+  `test/nonnative.yml`, `test/.config/**`, and related feature helpers are
+  intentional local harness assumptions unless there is concrete evidence of
+  current workflow breakage. Do not report the lack of environment-configurable
+  HTTP, gRPC, or observability endpoints as a feature gap by default.
 
 ## First steps
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,1 +1,2 @@
+include ../bin/build/make/help.mak
 include ../bin/build/make/ruby.mak

--- a/test/features/step_definitions/health/transport/http/observability_steps.rb
+++ b/test/features/step_definitions/health/transport/http/observability_steps.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
 When('the system requests the {string} with HTTP') do |name|
-  opts = {
-    headers: { request_id: SecureRandom.uuid },
-    read_timeout: 10, open_timeout: 10
-  }
+  opts = Standort.http_options
 
   @response = Nonnative.observability.send(name, opts)
 end

--- a/test/features/step_definitions/v1/transport/http/api_steps.rb
+++ b/test/features/step_definitions/v1/transport/http/api_steps.rb
@@ -3,13 +3,12 @@
 When('I request a location by IP address with HTTP:') do |table|
   rows = table.rows_hash
   @request_id = SecureRandom.uuid
-  opts = {
+  opts = Standort.http_options(
     headers: {
       request_id: @request_id, user_agent: Standort.config.transport.http.user_agent,
       content_type: :json, accept: :json
-    },
-    read_timeout: 10, open_timeout: 10
-  }
+    }
+  )
 
   @response = Standort::V1.http.get_location_by_ip(rows['ip'].strip, opts)
 end
@@ -17,13 +16,12 @@ end
 When('I request a location by latitude and longitude with HTTP:') do |table|
   rows = table.rows_hash
   @request_id = SecureRandom.uuid
-  opts = {
+  opts = Standort.http_options(
     headers: {
       request_id: @request_id, user_agent: Standort.config.transport.http.user_agent,
       content_type: :json, accept: :json
-    },
-    read_timeout: 10, open_timeout: 10
-  }
+    }
+  )
 
   @response = Standort::V1.http.get_location_by_lat_lng(rows['latitude'], rows['longitude'], opts)
 end

--- a/test/features/step_definitions/v2/transport/http/api_steps.rb
+++ b/test/features/step_definitions/v2/transport/http/api_steps.rb
@@ -3,13 +3,12 @@
 When('I request a location with HTTP:') do |table|
   rows = table.rows_hash
   @request_id = SecureRandom.uuid
-  opts = {
+  opts = Standort.http_options(
     headers: {
       request_id: @request_id, user_agent: 'Standort-ruby-client/2.0 HTTP/1.0',
       content_type: :json, accept: :json
-    },
-    read_timeout: 10, open_timeout: 10
-  }
+    }
+  )
 
   params = {}
 

--- a/test/features/step_definitions/v2/transport/http/benchmark_steps.rb
+++ b/test/features/step_definitions/v2/transport/http/benchmark_steps.rb
@@ -2,13 +2,12 @@
 
 When('I request a location with HTTP which performs in {int} ms') do |time|
   @request_id = SecureRandom.uuid
-  opts = {
+  opts = Standort.http_options(
     headers: {
       request_id: @request_id, user_agent: 'Standort-ruby-client/2.0 HTTP/1.0',
       content_type: :json, accept: :json
-    },
-    read_timeout: 10, open_timeout: 10
-  }
+    }
+  )
   params = { ip: '95.91.246.242' }
   response = nil
 

--- a/test/lib/standort.rb
+++ b/test/lib/standort.rb
@@ -67,6 +67,26 @@ module Standort
     end
 
     ##
+    # Returns bounded per-call options for HTTP feature-harness requests.
+    #
+    # Each call includes a generated `request_id` header. Caller-provided
+    # headers are merged afterward, so scenarios can override that value or add
+    # transport-specific headers such as content type and user agent.
+    #
+    # @param headers [Hash] HTTP headers merged after the generated request id.
+    # @param read_timeout [Integer] read timeout in seconds.
+    # @param open_timeout [Integer] connection open timeout in seconds.
+    # @return [Hash] Options compatible with `Nonnative::HTTPClient` calls.
+    #
+    def http_options(headers: {}, read_timeout: 10, open_timeout: 10)
+      {
+        headers: { request_id: SecureRandom.uuid }.merge(headers),
+        read_timeout:,
+        open_timeout:
+      }
+    end
+
+    ##
     # Returns a memoized gRPC Health Checking stub.
     #
     # This is used by health/observability feature steps to query the server's


### PR DESCRIPTION
## What

- Centralize HTTP feature-harness request options behind `Standort.http_options` while preserving caller-provided request IDs and transport headers.
- Expose the Ruby harness help target from `test/Makefile` and ignore the temporary `FEATURES.md` ledger.
- Add repository guidance for shared-bin CI preflight ownership and intentional local harness endpoint assumptions.

## Why

- Shared HTTP request options remove repeated timeout and request-id setup across HTTP API, benchmark, and observability steps.
- The Ruby harness command surface is now discoverable from `test/`, and repo-local guidance keeps accepted boundaries from resurfacing as future feature-gap findings.

## Testing

- `git diff --check` - passed.
- `gmake -C test help` - passed.
- `gmake lint` - failed after Go lint reported `0 issues`; Ruby lint could not start because the local system Ruby cannot activate Bundler `4.0.11` required by `test/Gemfile.lock`.
- `gmake features` - failed before Cucumber started for the same missing Bundler `4.0.11` environment issue.
