### PR TITLE
build(ci): tighten project workflow defaults

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,23 +14,23 @@ jobs:
       - restore_cache:
           name: restore go cache
           keys:
-            - standort-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}-{{ checksum ".source-key" }}
+            - standort-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}
             - standort-go-cache-
       - restore_cache:
           name: restore ruby cache
           keys:
-            - standort-ruby-cache-{{ checksum "test/Gemfile.lock" }}-{{ checksum "~/.ruby-version" }}-{{ checksum ".source-key" }}
+            - standort-ruby-cache-{{ checksum "test/Gemfile.lock" }}-{{ checksum "~/.ruby-version" }}
             - standort-ruby-cache-
       - run: make clean
       - run: make dep
       - save_cache:
           name: save go cache
-          key: standort-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}-{{ checksum ".source-key" }}
+          key: standort-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}
           paths:
             - ~/go/pkg/mod
       - save_cache:
           name: save ruby cache
-          key: standort-ruby-cache-{{ checksum "test/Gemfile.lock" }}-{{ checksum "~/.ruby-version" }}-{{ checksum ".source-key" }}
+          key: standort-ruby-cache-{{ checksum "test/Gemfile.lock" }}-{{ checksum "~/.ruby-version" }}
           paths:
             - test/vendor
       - restore_cache:
@@ -92,7 +92,7 @@ jobs:
       - restore_cache:
           name: restore go cache
           keys:
-            - standort-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}-{{ checksum ".source-key" }}
+            - standort-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}
             - standort-go-cache-
       - restore_cache:
           name: restore go build cache

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist
 .source-key
 ISSUES.md
 FEATURES.md
+PROJECTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,21 @@ This repository is a Go service called **standort** (location-based information)
 - If a one-command local CI preflight target is needed, add it to the shared
   `bin` Make fragments rather than as a service-local target here. Do not report
   the absence of a root `verify`/`ci-checks` target as a feature gap by default.
+- CircleCI's `version` job runs the external `package` command from
+  `alexfalkowski/release` / `alexfalkowski/docker/release`. That release image's
+  `release/package` script runs `goreleaser check "$releaser"` before
+  `goreleaser release`, so do not report the absence of a separate
+  repository-local GoReleaser validation job as a project gap by default unless
+  there is concrete evidence that the release image no longer validates
+  `.goreleaser.yml`, or this repository has explicitly decided to own a
+  pre-release GoReleaser check locally.
+- Ruby runtime selection for the `test/` harness is owned by the external
+  `alexfalkowski/ruby` image from `alexfalkowski/docker/ruby`. Do not report the
+  absence of a repository-local `.ruby-version`, `.tool-versions`, `mise.toml`,
+  or Gemfile `ruby` directive as a project gap by default unless there is
+  concrete evidence that the Ruby CI image no longer supplies the expected
+  runtime, or this repository has explicitly decided to own Ruby version
+  selection locally for the test harness.
 - The Ruby code under `test/` is a local feature/benchmark harness, not
   production service code. Fixed localhost endpoints in `test/lib/**`,
   `test/nonnative.yml`, `test/.config/**`, and related feature helpers are

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,1 +1,2 @@
 include ../bin/build/make/buf.mak
+include ../bin/build/make/help.mak


### PR DESCRIPTION
## What

- Narrow CircleCI dependency cache keys so Go module and Ruby bundle caches no longer depend on the broad repository source hash.
- Keep source-sensitive invalidation for Go build and lint caches.
- Add shared help discovery to the API Makefile while preserving the existing default API lint dry-run behavior.
- Capture repository review guardrails for GoReleaser validation and Ruby runtime ownership in AGENTS.md.

## Why

- Reduces unnecessary dependency cache churn from unrelated source, docs, config, or fixture edits.
- Makes API subdirectory commands discoverable the same way root and test commands are.
- Prevents future project-gap reviews from resurfacing release-image and Ruby-image responsibilities as local repository work.

## Testing

- `circleci config validate .circleci/config.yml` - passed
- `make -C api help` - passed
- `make -C test help` - passed
- `make -C api -n` - passed
- `make -C api -n lint` - passed
- `make -C api -n generate` - passed
- `make -C api -n breaking` - passed
- `make -C api -n format` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
