### PR TITLE
docs(agents): align CI parity docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,13 +231,22 @@ make trivy-image platform=amd64
 CircleCI runs (see `.circleci/config.yml`):
 - `make dep`, `make lint`, `make proto-breaking`, `make proto-stale`, `make sec`, `make features`, `make benchmarks`, `make analyse`, `make coverage`, `make codecov-upload`.
 
-If you’re trying to match CI locally, start with:
+If you’re trying to match CI locally, use the same target sequence:
 
 ```sh
 make dep
 make lint
-make specs
+make proto-breaking
+make proto-stale
+make sec
+make features
+make benchmarks
+make analyse
+make coverage
 ```
+
+Use `make specs` as a focused Go test check; it is not a separate CircleCI
+step in the main build job.
 
 ## Common gotchas (observed)
 

--- a/README.md
+++ b/README.md
@@ -384,13 +384,25 @@ make trivy-repo
 
 ### ✅ CI parity
 
-CircleCI initializes submodules, vendors dependencies, then runs linting, protobuf breaking and generated-output stale checks, security checks, feature tests, benchmarks, analysis, coverage, and Codecov upload. For a focused local pre-push check, start with:
+CircleCI initializes submodules, vendors dependencies, then runs linting,
+protobuf breaking and generated-output stale checks, security checks, feature
+tests, benchmarks, analysis, coverage, and Codecov upload. To mirror the main
+validation sequence locally, use:
 
 ```sh
 make dep
 make lint
-make specs
+make proto-breaking
+make proto-stale
+make sec
+make features
+make benchmarks
+make analyse
+make coverage
 ```
+
+Use `make specs` as a focused Go test check; it is not a separate CircleCI
+step in the main build job.
 
 ---
 


### PR DESCRIPTION
Document the full CircleCI validation sequence and clarify the role of specs.
