### PR TITLE
feat(location): normalize australia continent codes

### DIFF
--- a/internal/location/continent/continent.go
+++ b/internal/location/continent/continent.go
@@ -22,6 +22,7 @@ package continent
 // whole process.
 var Codes = map[string]string{
 	"Africa":        "AF",
+	"Australia":     "OC",
 	"North America": "NA",
 	"Oceania":       "OC",
 	"Asia":          "AS",

--- a/internal/location/continent/doc.go
+++ b/internal/location/continent/doc.go
@@ -12,6 +12,7 @@
 //
 //   - "Africa"        → "AF"
 //   - "Antarctica"    → "AN"
+//   - "Australia"     → "OC"
 //   - "Asia"          → "AS"
 //   - "Europe"        → "EU"
 //   - "North America" → "NA"

--- a/internal/location/location.go
+++ b/internal/location/location.go
@@ -13,10 +13,6 @@ import (
 	orb "github.com/alexfalkowski/standort/v2/internal/location/orb/provider"
 )
 
-// ErrUnsupportedContinent is returned when a provider resolves a continent name
-// that cannot be normalized to the API's two-letter continent code.
-var ErrUnsupportedContinent = errors.New("unsupported continent")
-
 // ErrInvalidPoint is returned when latitude or longitude is non-finite or outside
 // the supported geographic coordinate range.
 var ErrInvalidPoint = errors.New("invalid point")
@@ -68,12 +64,7 @@ func (l *Location) GetByIP(ctx context.Context, ip string) (string, string, erro
 		return strings.Empty, strings.Empty, err
 	}
 
-	code, err := continentCode(cont)
-	if err != nil {
-		return strings.Empty, strings.Empty, err
-	}
-
-	return country, code, nil
+	return country, continent.Codes[cont], nil
 }
 
 // GetByLatLng resolves a location from a latitude/longitude coordinate.
@@ -89,17 +80,12 @@ func (l *Location) GetByLatLng(ctx context.Context, lat, lng float64) (string, s
 		return strings.Empty, strings.Empty, fmt.Errorf("%f/%f: %w", lat, lng, ErrInvalidPoint)
 	}
 
-	cou, con, err := l.orbProvider.Search(ctx, lat, lng)
+	cou, cont, err := l.orbProvider.Search(ctx, lat, lng)
 	if err != nil {
 		return strings.Empty, strings.Empty, fmt.Errorf("%f/%f: %w", lat, lng, err)
 	}
 
-	code, err := continentCode(con)
-	if err != nil {
-		return strings.Empty, strings.Empty, fmt.Errorf("%f/%f: %w", lat, lng, err)
-	}
-
-	return cou, code, nil
+	return cou, continent.Codes[cont], nil
 }
 
 func validPoint(lat, lng float64) bool {
@@ -107,13 +93,4 @@ func validPoint(lat, lng float64) bool {
 		!math.IsInf(lat, 0) && !math.IsInf(lng, 0) &&
 		lat >= -90 && lat <= 90 &&
 		lng >= -180 && lng <= 180
-}
-
-func continentCode(cont string) (string, error) {
-	code, ok := continent.Codes[cont]
-	if !ok {
-		return strings.Empty, fmt.Errorf("%s: %w", cont, ErrUnsupportedContinent)
-	}
-
-	return code, nil
 }

--- a/test/features/v1/transport/grpc/api.feature
+++ b/test/features/v1/transport/grpc/api.feature
@@ -21,12 +21,12 @@ Feature: gRPC API
     Then I should receive a not found response with gRPC
 
     Examples: With geoip2
-      | source | ip      |
-      | geoip2 | 0.0.0.0 |
-      | geoip2 | test    |
-      | geoip2 | <test>  |
-      | geoip2 |   154.6 |
-      | geoip2 | 1.0.4.1 |
+      | source | ip        |
+      | geoip2 | 0.0.0.0   |
+      | geoip2 | test      |
+      | geoip2 | <test>    |
+      | geoip2 | 154.6     |
+      | geoip2 | 192.0.2.1 |
 
   Scenario Outline: Get location by a valid latitude and longitude.
     When I request a location by latitude and longitude with gRPC:

--- a/test/features/v1/transport/http/api.feature
+++ b/test/features/v1/transport/http/api.feature
@@ -21,13 +21,13 @@ Feature: HTTP API
     Then I should receive a not found response with HTTP
 
     Examples: With geoip2
-      | source | ip      |
-      | geoip2 | 0.0.0.0 |
-      | geoip2 | test    |
-      | geoip2 | <test>  |
-      | geoip2 |   154.6 |
-      | geoip2 | 1.0.4.1 |
-      | geoip2 |         |
+      | source | ip        |
+      | geoip2 | 0.0.0.0   |
+      | geoip2 | test      |
+      | geoip2 | <test>    |
+      | geoip2 | 154.6     |
+      | geoip2 | 192.0.2.1 |
+      | geoip2 |           |
 
   Scenario Outline: Get location by a valid latitude and longitude.
     When I request a location by latitude and longitude with HTTP:

--- a/test/features/v2/transport/grpc/api.feature
+++ b/test/features/v2/transport/grpc/api.feature
@@ -16,6 +16,7 @@ Feature: gRPC API
       | geoip2 | params | ip   |                           95.91.246.242 | DE      | EU        |
       | geoip2 | params | ip   |                          45.128.199.236 | NL      | EU        |
       | geoip2 | params | ip   |                             154.6.22.65 | US      | NA        |
+      | geoip2 | params | ip   |                                1.40.0.0 | AU      | OC        |
       | geoip2 | params | ip   | 2a02:8109:9f2e:4600:861e:b845:8bd4:b047 | DE      | EU        |
 
     Examples: With geoip2 metadata
@@ -31,20 +32,20 @@ Feature: gRPC API
     Then I should receive a not found response with gRPC
 
     Examples: With geoip2 parameters
-      | source | method | ip      |
-      | geoip2 | params | 0.0.0.0 |
-      | geoip2 | params | test    |
-      | geoip2 | params | <test>  |
-      | geoip2 | params | 154.6   |
-      | geoip2 | params | 1.0.4.1 |
+      | source | method | ip        |
+      | geoip2 | params | 0.0.0.0   |
+      | geoip2 | params | test      |
+      | geoip2 | params | <test>    |
+      | geoip2 | params | 154.6     |
+      | geoip2 | params | 192.0.2.1 |
 
     Examples: With geoip2 metadata
-      | source | method   | ip      |
-      | geoip2 | metadata | 0.0.0.0 |
-      | geoip2 | metadata | test    |
-      | geoip2 | metadata | <test>  |
-      | geoip2 | metadata | 154.6   |
-      | geoip2 | metadata | 1.0.4.1 |
+      | source | method   | ip        |
+      | geoip2 | metadata | 0.0.0.0   |
+      | geoip2 | metadata | test      |
+      | geoip2 | metadata | <test>    |
+      | geoip2 | metadata | 154.6     |
+      | geoip2 | metadata | 192.0.2.1 |
 
   Scenario Outline: Get location by a valid latitude and longitude.
     When I request a location with gRPC:

--- a/test/features/v2/transport/http/api.feature
+++ b/test/features/v2/transport/http/api.feature
@@ -16,12 +16,14 @@ Feature: HTTP API
       | geoip2 | params | ip   |  95.91.246.242 | DE      | EU        |
       | geoip2 | params | ip   | 45.128.199.236 | NL      | EU        |
       | geoip2 | params | ip   |    154.6.22.65 | US      | NA        |
+      | geoip2 | params | ip   |       1.40.0.0 | AU      | OC        |
 
     Examples: With geoip2 headers
       | source | method  | kind | ip             | country | continent |
       | geoip2 | headers | ip   |  95.91.246.242 | DE      | EU        |
       | geoip2 | headers | ip   | 45.128.199.236 | NL      | EU        |
       | geoip2 | headers | ip   |    154.6.22.65 | US      | NA        |
+      | geoip2 | headers | ip   |       1.40.0.0 | AU      | OC        |
 
   Scenario Outline: Get location by an bad IP address.
     When I request a location with HTTP:
@@ -30,20 +32,20 @@ Feature: HTTP API
     Then I should receive a not found response with HTTP
 
     Examples: With geoip2 parameters
-      | source | method | ip      |
-      | geoip2 | params | 0.0.0.0 |
-      | geoip2 | params | test    |
-      | geoip2 | params | <test>  |
-      | geoip2 | params |   154.6 |
-      | geoip2 | params | 1.0.4.1 |
+      | source | method | ip        |
+      | geoip2 | params | 0.0.0.0   |
+      | geoip2 | params | test      |
+      | geoip2 | params | <test>    |
+      | geoip2 | params | 154.6     |
+      | geoip2 | params | 192.0.2.1 |
 
     Examples: With geoip2 headers
-      | source | method  | ip      |
-      | geoip2 | headers | 0.0.0.0 |
-      | geoip2 | headers | test    |
-      | geoip2 | headers | <test>  |
-      | geoip2 | headers |   154.6 |
-      | geoip2 | headers | 1.0.4.1 |
+      | source | method  | ip        |
+      | geoip2 | headers | 0.0.0.0   |
+      | geoip2 | headers | test      |
+      | geoip2 | headers | <test>    |
+      | geoip2 | headers | 154.6     |
+      | geoip2 | headers | 192.0.2.1 |
 
   Scenario Outline: Get location by a valid latitude and longitude.
     When I request a location with HTTP:


### PR DESCRIPTION
## What

- Normalize provider-emitted `Australia` continent names to the public `OC` continent code.
- Add AU/Oceania regression coverage for v2 gRPC and HTTP IP lookups through the Ruby feature harness.
- Replace the stale `1.0.4.1` not-found fixture with `192.0.2.1` across v1/v2 HTTP and gRPC feature examples, because `1.0.4.1` now resolves through the corrected path.

## Why

- Valid GeoIP lookups for countries whose `gountries` data reports continent `Australia` were being rejected as unsupported instead of returning `OC`.
- Normalizing that provider label fixes the whole affected class while preserving the public API continent code contract.

## Testing

- `git diff --check` - passed
- `go test ./internal/location/... ./internal/api/location/... ./internal/api/v1/... ./internal/api/v2/...` - passed
- `make features` - passed
- `make lint` - passed
