### PR TITLE
feat(http): introduce transport server constructors

### DIFF
--- a/internal/api/v1/module.go
+++ b/internal/api/v1/module.go
@@ -12,12 +12,13 @@ import (
 // It registers:
 //   - the v1 location module (`location.Module`), which builds generated v1 responses
 //   - the v1 gRPC server implementation (`grpc.NewServer`) and its gRPC registration (`grpc.Register`)
-//   - the v1 HTTP routing registration (`http.Register`)
+//   - the v1 HTTP server implementation (`http.NewServer`) and its HTTP routing registration (`http.Register`)
 //
 // This module is intended to be included by the top-level server composition (see `internal/cmd.Module`).
 var Module = di.Module(
 	location.Module,
 	di.Constructor(grpc.NewServer),
 	di.Register(grpc.Register),
+	di.Constructor(http.NewServer),
 	di.Register(http.Register),
 )

--- a/internal/api/v1/transport/http/doc.go
+++ b/internal/api/v1/transport/http/doc.go
@@ -1,22 +1,23 @@
 // Package http provides the Standort API v1 HTTP transport wiring.
 //
-// The v1 API is exposed over HTTP by routing RPC-style HTTP requests to
-// transport-specific handler functions.
+// The v1 API is exposed over HTTP by routing RPC-style HTTP requests to a
+// concrete transport server.
 //
 // # Routing
 //
 // `Register` maps the generated full method names to the corresponding HTTP
-// handlers:
+// server handlers:
 //
-//   - `standort.v1.Service/GetLocationByIP` → `getLocationByIP`
-//   - `standort.v1.Service/GetLocationByLatLng` → `getLocationByLatLng`
+//   - `standort.v1.Service/GetLocationByIP` → `Server.GetLocationByIP`
+//   - `standort.v1.Service/GetLocationByLatLng` → `Server.GetLocationByLatLng`
 //
 // The route shapes (paths, verbs, encoding) are defined by the go-service RPC
 // router (`rpc.Route`). This package is responsible only for wiring the routes
-// to `internal/api/v1/location.Locator`.
+// to a `Server`.
 //
 // # Dependency injection
 //
-// The v1 API module (`internal/api/v1.Module`) registers this package's `Register`
-// function into the application's dependency injection graph.
+// The v1 API module (`internal/api/v1.Module`) registers this package's
+// `NewServer` constructor and `Register` function into the application's
+// dependency injection graph.
 package http

--- a/internal/api/v1/transport/http/http.go
+++ b/internal/api/v1/transport/http/http.go
@@ -11,12 +11,24 @@ import (
 // This package uses go-service's RPC routing, mapping the generated full method
 // names to the corresponding HTTP handlers:
 //
-//   - `standort.v1.Service/GetLocationByIP` → `getLocationByIP`
-//   - `standort.v1.Service/GetLocationByLatLng` → `getLocationByLatLng`
+//   - `standort.v1.Service/GetLocationByIP` → `Server.GetLocationByIP`
+//   - `standort.v1.Service/GetLocationByLatLng` → `Server.GetLocationByLatLng`
 //
 // The HTTP server and route shapes are provided by `rpc.Route`; this function
-// only wires the routes to the v1 locator.
-func Register(locator *location.Locator) {
-	rpc.Route(v1.Service_GetLocationByIP_FullMethodName, getLocationByIP(locator))
-	rpc.Route(v1.Service_GetLocationByLatLng_FullMethodName, getLocationByLatLng(locator))
+// only wires the routes to the v1 server.
+func Register(server *Server) {
+	rpc.Route(v1.Service_GetLocationByIP_FullMethodName, server.GetLocationByIP)
+	rpc.Route(v1.Service_GetLocationByLatLng_FullMethodName, server.GetLocationByLatLng)
+}
+
+// NewServer constructs a v1 HTTP `Server`.
+//
+// The returned server delegates response construction to the provided v1 locator.
+func NewServer(locator *location.Locator) *Server {
+	return &Server{locator: locator}
+}
+
+// Server implements the v1 HTTP transport handlers.
+type Server struct {
+	locator *location.Locator
 }

--- a/internal/api/v1/transport/http/location.go
+++ b/internal/api/v1/transport/http/location.go
@@ -5,27 +5,32 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	v1 "github.com/alexfalkowski/standort/v2/api/standort/v1"
-	"github.com/alexfalkowski/standort/v2/internal/api/v1/location"
 )
 
-func getLocationByIP(locator *location.Locator) func(context.Context, *v1.GetLocationByIPRequest) (*v1.GetLocationByIPResponse, error) {
-	return func(ctx context.Context, req *v1.GetLocationByIPRequest) (*v1.GetLocationByIPResponse, error) {
-		resp, err := locator.LocateByIP(ctx, req)
-		if err != nil {
-			return nil, status.SafeError(http.StatusNotFound, err)
-		}
-
-		return resp, nil
+// GetLocationByIP resolves a location from an IP address.
+//
+// The handler delegates response construction to the v1 locator. If the
+// underlying lookup returns an error, no response body is returned and the error
+// is mapped to an HTTP 404 response.
+func (s *Server) GetLocationByIP(ctx context.Context, req *v1.GetLocationByIPRequest) (*v1.GetLocationByIPResponse, error) {
+	resp, err := s.locator.LocateByIP(ctx, req)
+	if err != nil {
+		return nil, status.SafeError(http.StatusNotFound, err)
 	}
+
+	return resp, nil
 }
 
-func getLocationByLatLng(locator *location.Locator) func(context.Context, *v1.GetLocationByLatLngRequest) (*v1.GetLocationByLatLngResponse, error) {
-	return func(ctx context.Context, req *v1.GetLocationByLatLngRequest) (*v1.GetLocationByLatLngResponse, error) {
-		resp, err := locator.LocateByLatLng(ctx, req)
-		if err != nil {
-			return nil, status.SafeError(http.StatusNotFound, err)
-		}
-
-		return resp, nil
+// GetLocationByLatLng resolves a location from a latitude/longitude coordinate.
+//
+// The handler delegates response construction to the v1 locator. If the
+// underlying lookup returns an error, no response body is returned and the error
+// is mapped to an HTTP 404 response.
+func (s *Server) GetLocationByLatLng(ctx context.Context, req *v1.GetLocationByLatLngRequest) (*v1.GetLocationByLatLngResponse, error) {
+	resp, err := s.locator.LocateByLatLng(ctx, req)
+	if err != nil {
+		return nil, status.SafeError(http.StatusNotFound, err)
 	}
+
+	return resp, nil
 }

--- a/internal/api/v2/module.go
+++ b/internal/api/v2/module.go
@@ -13,12 +13,13 @@ import (
 //   - the v2 location module (`location.Module`), which composes the lower-level
 //     transport-facing locator and v2 response locator
 //   - the v2 gRPC server implementation (`grpc.NewServer`) and its gRPC registration (`grpc.Register`)
-//   - the v2 HTTP routing registration (`http.Register`)
+//   - the v2 HTTP server implementation (`http.NewServer`) and its HTTP routing registration (`http.Register`)
 //
 // This module is intended to be included by the top-level server composition (see `internal/cmd.Module`).
 var Module = di.Module(
 	location.Module,
 	di.Constructor(grpc.NewServer),
 	di.Register(grpc.Register),
+	di.Constructor(http.NewServer),
 	di.Register(http.Register),
 )

--- a/internal/api/v2/transport/http/doc.go
+++ b/internal/api/v2/transport/http/doc.go
@@ -1,21 +1,22 @@
 // Package http provides the Standort API v2 HTTP transport wiring.
 //
-// The v2 API is exposed over HTTP by routing RPC-style HTTP requests to
-// transport-specific handler functions.
+// The v2 API is exposed over HTTP by routing RPC-style HTTP requests to a
+// concrete transport server.
 //
 // # Routing
 //
-// Register maps the generated full method name to the corresponding HTTP handler:
+// Register maps the generated full method name to the corresponding HTTP server
+// handler:
 //
-//   - `standort.v2.Service/GetLocation` → `getLocation`
+//   - `standort.v2.Service/GetLocation` → `Server.GetLocation`
 //
 // The route shapes (paths, verbs, encoding) are defined by the go-service RPC
 // router (`rpc.Route`). This package is responsible only for wiring the route to
-// `internal/api/v2/location.Locator` and setting HTTP-specific diagnostics on
-// terminal lookup failures.
+// a `Server` and setting HTTP-specific diagnostics on terminal lookup failures.
 //
 // # Dependency injection
 //
-// The v2 API module (`internal/api/v2.Module`) registers this package's `Register`
-// function into the application's dependency injection graph.
+// The v2 API module (`internal/api/v2.Module`) registers this package's
+// `NewServer` constructor and `Register` function into the application's
+// dependency injection graph.
 package http

--- a/internal/api/v2/transport/http/http.go
+++ b/internal/api/v2/transport/http/http.go
@@ -14,12 +14,24 @@ import (
 // This package uses go-service's RPC routing, mapping the generated full method
 // name to the corresponding HTTP handler:
 //
-//   - `standort.v2.Service/GetLocation` → `getLocation`
+//   - `standort.v2.Service/GetLocation` → `Server.GetLocation`
 //
 // The HTTP server and route shapes are provided by `rpc.Route`; this function only
-// wires the route to the v2 locator.
-func Register(locator *location.Locator) {
-	rpc.Route(v2.Service_GetLocation_FullMethodName, getLocation(locator))
+// wires the route to the v2 server.
+func Register(server *Server) {
+	rpc.Route(v2.Service_GetLocation_FullMethodName, server.GetLocation)
+}
+
+// NewServer constructs a v2 HTTP `Server`.
+//
+// The returned server delegates response construction to the provided v2 locator.
+func NewServer(locator *location.Locator) *Server {
+	return &Server{locator: locator}
+}
+
+// Server implements the v2 HTTP transport handlers.
+type Server struct {
+	locator *location.Locator
 }
 
 func setFailureHeaders(ctx context.Context, values diagnostics.Values) {

--- a/internal/api/v2/transport/http/location.go
+++ b/internal/api/v2/transport/http/location.go
@@ -5,18 +5,21 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	v2 "github.com/alexfalkowski/standort/v2/api/standort/v2"
-	"github.com/alexfalkowski/standort/v2/internal/api/v2/location"
 	"github.com/alexfalkowski/standort/v2/internal/diagnostics"
 )
 
-func getLocation(locator *location.Locator) func(ctx context.Context, req *v2.GetLocationRequest) (*v2.GetLocationResponse, error) {
-	return func(ctx context.Context, req *v2.GetLocationRequest) (*v2.GetLocationResponse, error) {
-		resp, err := locator.Locate(ctx, req)
-		if err != nil {
-			setFailureHeaders(ctx, diagnostics.FromError(err))
-			return nil, status.SafeError(http.StatusNotFound, err)
-		}
-
-		return resp, nil
+// GetLocation resolves a location from request inputs.
+//
+// The handler delegates response construction to the v2 locator. If the
+// underlying lookup returns an error, diagnostic values are written as HTTP
+// headers, no response body is returned, and the error is mapped to an HTTP 404
+// response.
+func (s *Server) GetLocation(ctx context.Context, req *v2.GetLocationRequest) (*v2.GetLocationResponse, error) {
+	resp, err := s.locator.Locate(ctx, req)
+	if err != nil {
+		setFailureHeaders(ctx, diagnostics.FromError(err))
+		return nil, status.SafeError(http.StatusNotFound, err)
 	}
+
+	return resp, nil
 }


### PR DESCRIPTION
## What

- Adds typed HTTP transport servers for v1 and v2, with constructors registered in each API module.
- Routes RPC HTTP handlers through server methods instead of locator-bound closure factories.
- Updates package-level and exported API comments to describe server construction and routing.

## Why

- Aligns HTTP transport wiring with the existing gRPC server lifecycle, giving both API versions the same DI shape.
- Keeps route registration focused on transport servers while preserving existing lookup behavior and error/diagnostic mapping.

## Testing

- `make specs` - passed
- `make lint` - passed
- `git diff --check` - passed
- Local validation focused on compile, lint, and whitespace because this refactor preserves handler behavior.

AI-assisted-by: [Codex](https://openai.com/codex/)
