### PR TITLE
docs(readme): clarify v2 batch contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,14 +202,23 @@ make trivy-image platform=amd64
 - HTTP transport registers routes using generated full method name constants:
   - v1: `internal/api/v1/transport/http/http.go:9-13`
   - v2: `internal/api/v2/transport/http/http.go:9-12`
-- Error mapping: the gRPC transport `Server.error` converts **any non-nil error** to `codes.NotFound` (`internal/api/v2/transport/grpc/grpc.go:27-33` and similarly in v1).
+- Error mapping:
+  - v1 lookup errors map to gRPC `codes.NotFound` and HTTP `404`.
+  - v2 `GetLocation` terminal lookup failures map to gRPC `codes.NotFound`
+    or HTTP `404`, with safe diagnostics attached to transport metadata.
+  - v2 `LookupLocations` oversized batch requests map to gRPC
+    `codes.InvalidArgument` or HTTP `400`; per-entry misses stay in the
+    successful batch response as `google.rpc.Status`.
 
 ### Request metadata
 
 - v2 `Locator` can read inputs from metadata when the request doesn’t provide them:
   - IP: `meta.IPAddr(ctx).Value()` (`internal/api/location/location.go:86-92`).
   - Geolocation header: `meta.Geolocation(ctx)` parsed as a geo URI (`internal/api/location/location.go:99-110`).
-- v2 `Locator` records lookup errors as metadata attributes (e.g., `locationIpError`, `locationLatLngError`) and only returns `ErrNotFound` if **both** IP and GEO lookups are missing (`internal/api/location/location.go:53-83`).
+- v2 `Locator` records terminal lookup errors as safe metadata attributes
+  (for example, `location-ip-error`, `location-lat-lng-error`, or
+  `location-point-error`) and only returns `ErrNotFound` if **both** IP and
+  GEO lookups are missing.
 - Responses include request metadata via `meta.CamelStrings(ctx, "")` in the gRPC handlers:
   - v1: `internal/api/v1/transport/grpc/location.go:10-30`
   - v2: `internal/api/v2/transport/grpc/location.go:11-21`

--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ Terminal lookup failures return gRPC `NotFound`; the HTTP RPC router exposes the
 `LookupLocations` accepts up to 100 lookup entries and preserves request order
 in the response. Entries that resolve successfully populate `ip`, `geo`, or
 both. Entries that do not resolve any location populate a per-entry
-`google.rpc.Status` instead of failing the whole batch.
+`google.rpc.Status` instead of failing the whole batch. Requests with more than
+100 lookup entries fail the whole call with gRPC `InvalidArgument`; the HTTP RPC
+mapping returns `400`.
 
 `GetLookupAssets` returns read-only metadata for the embedded lookup assets,
 including asset name, size in bytes, checksum algorithm, and checksum. It is

--- a/api/standort/v2/service.pb.go
+++ b/api/standort/v2/service.pb.go
@@ -254,9 +254,11 @@ func (x *GetLocationResponse) GetGeo() *Location {
 // LocationLookup is one lookup entry for a batch request.
 type LocationLookup struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// IP address to resolve.
+	// IP address to resolve. If empty, the server may use request metadata such
+	// as X-Forwarded-For for this entry.
 	Ip string `protobuf:"bytes,1,opt,name=ip,proto3" json:"ip,omitempty"`
-	// Geographic point to resolve.
+	// Geographic point to resolve. If omitted, the server may use a Geolocation
+	// metadata header for this entry.
 	Point         *Point `protobuf:"bytes,2,opt,name=point,proto3" json:"point,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -309,7 +311,8 @@ func (x *LocationLookup) GetPoint() *Point {
 // LookupLocationsRequest for batch location lookup.
 type LookupLocationsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Lookups contains the entries to resolve. At most 100 lookups are supported.
+	// Lookups contains the entries to resolve. At most 100 lookups are supported;
+	// larger requests fail the whole call with gRPC InvalidArgument.
 	Lookups       []*LocationLookup `protobuf:"bytes,1,rep,name=lookups,proto3" json:"lookups,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/api/standort/v2/service.proto
+++ b/api/standort/v2/service.proto
@@ -48,16 +48,19 @@ message GetLocationResponse {
 
 // LocationLookup is one lookup entry for a batch request.
 message LocationLookup {
-  // IP address to resolve.
+  // IP address to resolve. If empty, the server may use request metadata such
+  // as X-Forwarded-For for this entry.
   string ip = 1;
 
-  // Geographic point to resolve.
+  // Geographic point to resolve. If omitted, the server may use a Geolocation
+  // metadata header for this entry.
   Point point = 2;
 }
 
 // LookupLocationsRequest for batch location lookup.
 message LookupLocationsRequest {
-  // Lookups contains the entries to resolve. At most 100 lookups are supported.
+  // Lookups contains the entries to resolve. At most 100 lookups are supported;
+  // larger requests fail the whole call with gRPC InvalidArgument.
   repeated LocationLookup lookups = 1;
 }
 
@@ -118,6 +121,7 @@ service Service {
   rpc GetLocation(GetLocationRequest) returns (GetLocationResponse) {}
 
   // LookupLocations resolves multiple location lookups, preserving request order.
+  // Missing entry inputs may fall back to request metadata for each entry.
   rpc LookupLocations(LookupLocationsRequest) returns (LookupLocationsResponse) {}
 
   // GetLookupAssets returns metadata for embedded lookup assets.

--- a/api/standort/v2/service_grpc.pb.go
+++ b/api/standort/v2/service_grpc.pb.go
@@ -36,6 +36,7 @@ type ServiceClient interface {
 	// terminal error metadata.
 	GetLocation(ctx context.Context, in *GetLocationRequest, opts ...grpc.CallOption) (*GetLocationResponse, error)
 	// LookupLocations resolves multiple location lookups, preserving request order.
+	// Missing entry inputs may fall back to request metadata for each entry.
 	LookupLocations(ctx context.Context, in *LookupLocationsRequest, opts ...grpc.CallOption) (*LookupLocationsResponse, error)
 	// GetLookupAssets returns metadata for embedded lookup assets.
 	GetLookupAssets(ctx context.Context, in *GetLookupAssetsRequest, opts ...grpc.CallOption) (*GetLookupAssetsResponse, error)
@@ -91,6 +92,7 @@ type ServiceServer interface {
 	// terminal error metadata.
 	GetLocation(context.Context, *GetLocationRequest) (*GetLocationResponse, error)
 	// LookupLocations resolves multiple location lookups, preserving request order.
+	// Missing entry inputs may fall back to request metadata for each entry.
 	LookupLocations(context.Context, *LookupLocationsRequest) (*LookupLocationsResponse, error)
 	// GetLookupAssets returns metadata for embedded lookup assets.
 	GetLookupAssets(context.Context, *GetLookupAssetsRequest) (*GetLookupAssetsResponse, error)

--- a/internal/api/v2/location/location.go
+++ b/internal/api/v2/location/location.go
@@ -13,7 +13,8 @@ import (
 
 const maxLookups = 100
 
-// ErrTooManyLookups is returned when a batch request exceeds the supported size.
+// ErrTooManyLookups is returned when a batch request contains more than 100
+// lookup entries.
 var ErrTooManyLookups = errors.New("too many lookups")
 
 // NewLocator constructs a v2 response locator.
@@ -41,6 +42,12 @@ func (l *Locator) Locate(ctx context.Context, req *v2.GetLocationRequest) (*v2.G
 }
 
 // Lookup resolves a v2 batch request.
+//
+// Responses preserve request order. Each lookup entry is resolved independently;
+// entries that do not resolve any location receive a per-entry `NotFound`
+// `google.rpc.Status` while the batch response still succeeds. The only
+// request-level error currently returned by this method is `ErrTooManyLookups`
+// when the request contains more than 100 entries.
 func (l *Locator) Lookup(ctx context.Context, req *v2.LookupLocationsRequest) (*v2.LookupLocationsResponse, error) {
 	lookups := req.GetLookups()
 	if len(lookups) > maxLookups {

--- a/internal/assets/assets.go
+++ b/internal/assets/assets.go
@@ -23,7 +23,11 @@ type File struct {
 // Files contains metadata for embedded lookup asset files.
 type Files []File
 
-// NewFiles constructs metadata for embedded lookup asset files.
+// NewFiles constructs metadata for the expected embedded lookup asset files.
+//
+// It reads `geoip2.mmdb` and `earth.geojson`, computes SHA-256 checksums, and
+// records each file's byte size. Construction fails through `runtime.Must` if
+// either expected file cannot be read from the embedded filesystem.
 func NewFiles(fs embed.FS) Files {
 	files := make(Files, 0, len(names))
 	for _, name := range names {

--- a/test/lib/standort/v2/service_services_pb.rb
+++ b/test/lib/standort/v2/service_services_pb.rb
@@ -22,6 +22,7 @@ module Standort
         # terminal error metadata.
         rpc :GetLocation, ::Standort::V2::GetLocationRequest, ::Standort::V2::GetLocationResponse
         # LookupLocations resolves multiple location lookups, preserving request order.
+        # Missing entry inputs may fall back to request metadata for each entry.
         rpc :LookupLocations, ::Standort::V2::LookupLocationsRequest, ::Standort::V2::LookupLocationsResponse
         # GetLookupAssets returns metadata for embedded lookup assets.
         rpc :GetLookupAssets, ::Standort::V2::GetLookupAssetsRequest, ::Standort::V2::GetLookupAssetsResponse


### PR DESCRIPTION
## What

- Clarify v2 batch lookup documentation across the README, proto comments, generated client comments, and maintainer GoDoc.
- Document that missing batch-entry inputs can fall back to request metadata and that oversized batches fail the whole call with gRPC `InvalidArgument` / HTTP `400`.
- Correct agent guidance for current transport error mapping and hyphenated diagnostic metadata keys.
- Document the embedded asset metadata constructor contract for expected files, SHA-256 checksums, byte sizes, and startup failure behavior.

## Why

- Prevent API integrators and maintainers from relying on stale or incomplete prose around v2 batch semantics.
- Keep generated contract comments and repository guidance aligned with the existing implementation and feature coverage.
- Make non-obvious maintainer contracts visible in GoDoc without changing runtime behavior.

## Testing

- `make proto-generate` - passed
- `make proto-lint` - passed
- `make lint` - passed
- `make proto-stale` - passed against the temporarily staged prospective patch, because the target regenerates outputs and checks `git diff --exit-code`.
- `git diff --check` - passed
