### PR TITLE
build(ci): restore protobuf breaking gate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,8 +68,7 @@ jobs:
           key: standort-go-lint-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-lint-version" }}-{{ checksum ".source-key" }}
           paths:
             - ~/.cache/golangci-lint
-      # TODO: Re-enable after the intentional v2 batch response breaking change lands.
-      # - run: make proto-breaking
+      - run: make proto-breaking
       - run: make proto-stale
       - run: make sec
       - run: make features


### PR DESCRIPTION
## What

- Restored the CircleCI `make proto-breaking` step after the intentional v2 API break was merged.
- Keeps the protobuf breaking-change gate active before stale-generation, security, feature, benchmark, analysis, and coverage jobs run.

## Why

- The temporary CI skip is no longer needed now that the breaking API change has landed.
- Re-enabling the check restores release protection for future protobuf contract changes.

## Testing

- `make lint` - passed
- `make proto-breaking` - passed
