### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.628.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	git.jlel.se/jlelse/go-geouri v0.0.0-20210525190615-a9c1d50f42d6
 	github.com/IncSW/geoip2 v0.1.4
 	github.com/alexfalkowski/go-health/v2 v2.33.0
-	github.com/alexfalkowski/go-service/v2 v2.626.0
+	github.com/alexfalkowski/go-service/v2 v2.628.0
 	github.com/pariz/gountries v0.1.6
 	github.com/paulmach/orb v0.13.0
 	github.com/tidwall/rtree v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.33.0 h1:25fFPDnuIhZjLP1FYvzTayOMpwyjppzaxBXj/TPmkM4=
 github.com/alexfalkowski/go-health/v2 v2.33.0/go.mod h1:H11y8kNp0Ks3ayUNwjPOAV4314lGeH8MuwolYV+6l0M=
-github.com/alexfalkowski/go-service/v2 v2.626.0 h1:2jftn/8V+pcb9cLPz/pccXuwD2zEMxtA64/xGc68GjE=
-github.com/alexfalkowski/go-service/v2 v2.626.0/go.mod h1:NMuzgFLt0LR1fP4uOrOtwF7CQktXE5Yxx+4DfU6xGUY=
+github.com/alexfalkowski/go-service/v2 v2.628.0 h1:HB582epDHWj91n9n5dp6z+NX0LpK9006KDjTKxaHnrE=
+github.com/alexfalkowski/go-service/v2 v2.628.0/go.mod h1:NMuzgFLt0LR1fP4uOrOtwF7CQktXE5Yxx+4DfU6xGUY=
 github.com/alexfalkowski/go-sync v1.27.0 h1:Mnk9mhspHt/NzMwFvTyikAla1QF3GDufzuA1v8zvdcY=
 github.com/alexfalkowski/go-sync v1.27.0/go.mod h1:2vmRtpHHSoGPIiXJ7j3lm0GK2SI32XbYvvrjrZ+eo/k=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.628.0
