### PR TITLE
build(deps): wire shared codex permissions

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,1 @@
+../bin/build/codex/config.toml

--- a/.codex/rules/bin.rules
+++ b/.codex/rules/bin.rules
@@ -1,0 +1,1 @@
+../../bin/build/codex/rules/default.rules


### PR DESCRIPTION
## What

- Advance the shared `bin` submodule to include the centralized Codex permission profile and host-execution guardrails.
- Wire this repository to the shared Codex configuration and rules through `.codex` symlinks while preserving repository-owned configuration boundaries.

## Why

- Adopt the shared baseline introduced by `alexfalkowski/bin#533`, reducing repeated per-repository approvals while retaining explicit gates for remote writes, destructive actions, credentials, and network access.

## Testing

- `make codex-init` - passed
- `codex execpolicy check --pretty --rules .codex/rules/bin.rules -- make review 'msg=test subject' 'desc_file=/private/tmp/review.md'` - passed; the review target resolves to `prompt`
- Symlink integrity, exact gitlink scope, nested-submodule cleanliness, and `git diff --check` - passed
- Application test suites were not run because the change is limited to the shared `bin` gitlink and generated Codex wiring.

AI-assisted-by: [Codex](https://openai.com/codex/)
