### PR TITLE
feat(batch-failure-details): return typed lookup diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ location populate a per-entry `google.rpc.Status` instead of failing the whole
 batch. Requests with more than 100 lookup entries fail the whole call with gRPC
 `InvalidArgument`; the HTTP RPC mapping returns `400`.
 
+For a classified batch failure, `status.details` contains one
+`google.rpc.ErrorInfo` with reason `LOCATION_LOOKUP_FAILED` and domain
+`standort.v2`. Its metadata preserves the safe, code-only diagnostic keys used
+by terminal lookup failures (such as `location-ip-error: not_found`). Clients
+must ignore unknown diagnostic keys and codes; no raw request input or provider
+error is included.
+
 For the HTTP mapping of `LookupLocations`, set the `Content-Type` header to
 `application/pbjson` to receive protobuf JSON where each lookup entry has either
 `locations` or `status`.

--- a/api/standort/v2/service.pb.go
+++ b/api/standort/v2/service.pb.go
@@ -435,7 +435,10 @@ type LocationLookupResponse_Locations struct {
 }
 
 type LocationLookupResponse_Status struct {
-	// Status is populated when this lookup does not resolve any location.
+	// Status is populated when this lookup does not resolve any location. When
+	// a safe diagnostic is available, Details contains one google.rpc.ErrorInfo
+	// with reason LOCATION_LOOKUP_FAILED, domain standort.v2, and code-only
+	// diagnostic metadata.
 	Status *status.Status `protobuf:"bytes,2,opt,name=status,proto3,oneof"`
 }
 

--- a/api/standort/v2/service.proto
+++ b/api/standort/v2/service.proto
@@ -81,7 +81,10 @@ message LocationLookupResponse {
     // Locations is populated when this lookup resolves at least one location.
     ResolvedLocations locations = 1;
 
-    // Status is populated when this lookup does not resolve any location.
+    // Status is populated when this lookup does not resolve any location. When
+    // a safe diagnostic is available, Details contains one google.rpc.ErrorInfo
+    // with reason LOCATION_LOOKUP_FAILED, domain standort.v2, and code-only
+    // diagnostic metadata.
     google.rpc.Status status = 2;
   }
 }

--- a/internal/api/v2/location/location.go
+++ b/internal/api/v2/location/location.go
@@ -1,6 +1,8 @@
 package location
 
 import (
+	"fmt"
+
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/meta"
@@ -8,10 +10,17 @@ import (
 	"github.com/alexfalkowski/go-service/v2/strings"
 	v2 "github.com/alexfalkowski/standort/v2/api/standort/v2"
 	"github.com/alexfalkowski/standort/v2/internal/api/location"
+	"github.com/alexfalkowski/standort/v2/internal/diagnostics"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
-const maxLookups = 100
+const (
+	maxLookups      = 100
+	errorInfoReason = "LOCATION_LOOKUP_FAILED"
+	errorInfoDomain = "standort.v2"
+)
 
 // ErrTooManyLookups is returned when a batch request contains more than 100
 // lookup entries.
@@ -63,12 +72,27 @@ func (l *Locator) Lookup(ctx context.Context, req *v2.LookupLocationsRequest) (*
 	for _, lookup := range lookups {
 		locations, err := l.locator.Locate(ctx, lookup.GetIp(), toPoint(lookup.GetPoint()))
 		if err != nil {
+			values := diagnostics.FromError(err)
+			entryStatus := &status.Status{
+				Code:    int32(codes.NotFound),
+				Message: location.ErrNotFound.Error(),
+			}
+			if len(values) > 0 {
+				detail, err := anypb.New(&errdetails.ErrorInfo{
+					Reason:   errorInfoReason,
+					Domain:   errorInfoDomain,
+					Metadata: values.Map(),
+				})
+				if err != nil {
+					return nil, fmt.Errorf("error info: %w", err)
+				}
+
+				entryStatus.Details = []*anypb.Any{detail}
+			}
+
 			resp.Lookups = append(resp.Lookups, &v2.LocationLookupResponse{
 				Outcome: &v2.LocationLookupResponse_Status{
-					Status: &status.Status{
-						Code:    int32(codes.NotFound),
-						Message: location.ErrNotFound.Error(),
-					},
+					Status: entryStatus,
 				},
 			})
 			continue

--- a/test/features/step_definitions/v2/transport/grpc/api_steps.rb
+++ b/test/features/step_definitions/v2/transport/grpc/api_steps.rb
@@ -31,7 +31,12 @@ end
 When('I lookup locations with gRPC:') do |table|
   @request_id = SecureRandom.uuid
   metadata = { 'request-id' => @request_id }
-  lookups = table.hashes.map do |row|
+  @lookup_positions = {}
+  lookups = table.hashes.each_with_index.map do |row, lookup_position|
+    lookup_label = row.fetch('lookup')
+    raise "duplicate lookup label: #{lookup_label}" if @lookup_positions.key?(lookup_label)
+
+    @lookup_positions[lookup_label] = lookup_position
     params = {}
     params[:ip] = row['ip'] unless row['ip'].empty?
     if !row['latitude'].empty? && !row['longitude'].empty?
@@ -45,6 +50,22 @@ When('I lookup locations with gRPC:') do |table|
   end
 
   request = Standort::V2::LookupLocationsRequest.new(lookups:)
+  @response = Standort::V2.grpc.lookup_locations(request, Standort.grpc_options(metadata))
+rescue StandardError => e
+  @response = e
+end
+
+When('I lookup a location using metadata with gRPC:') do |table|
+  @request_id = SecureRandom.uuid
+  rows = table.rows_hash
+  metadata = {
+    'request-id' => @request_id,
+    'x-forwarded-for' => rows['ip'],
+    'geolocation' => rows['geolocation']
+  }
+  lookup = Standort::V2::LocationLookup.new
+  request = Standort::V2::LookupLocationsRequest.new(lookups: [lookup])
+  @lookup_positions = { rows.fetch('lookup') => 0 }
   @response = Standort::V2.grpc.lookup_locations(request, Standort.grpc_options(metadata))
 rescue StandardError => e
   @response = e
@@ -112,7 +133,7 @@ Then('I should receive batch locations with gRPC:') do |table|
   expect(@response.meta['requestId']).to eq(@request_id)
 
   table.hashes.each do |row|
-    lookup = @response.lookups.fetch(row['index'].to_i)
+    lookup = @response.lookups.fetch(@lookup_positions.fetch(row['lookup']))
     location = case row['kind']
                when 'ip'
                  expect(lookup.status).to be_nil
@@ -132,6 +153,27 @@ Then('I should receive batch locations with gRPC:') do |table|
 
     expect(location.country).to eq(row['country'])
     expect(location.continent).to eq(row['continent'])
+  end
+end
+
+Then('I should receive batch diagnostics with gRPC:') do |table|
+  expect(@response.meta['requestId']).to eq(@request_id)
+
+  table.hashes.group_by { |row| row['lookup'] }.each do |lookup_label, rows|
+    lookup = @response.lookups.fetch(@lookup_positions.fetch(lookup_label))
+    status = lookup.status
+    detail = status.details.fetch(0)
+    error_info = Google::Rpc::ErrorInfo.decode(detail.value)
+    expected_metadata = rows.to_h { |row| [row['diagnostic'], row['code']] }
+
+    expect(lookup.locations).to be_nil
+    expect(status.code).to eq(5)
+    expect(status.message).to eq('not found')
+    expect(status.details.length).to eq(1)
+    expect(detail.type_url).to eq('type.googleapis.com/google.rpc.ErrorInfo')
+    expect(error_info.reason).to eq('LOCATION_LOOKUP_FAILED')
+    expect(error_info.domain).to eq('standort.v2')
+    expect(error_info.metadata.to_h).to eq(expected_metadata)
   end
 end
 

--- a/test/features/step_definitions/v2/transport/http/api_steps.rb
+++ b/test/features/step_definitions/v2/transport/http/api_steps.rb
@@ -34,7 +34,12 @@ When('I lookup locations with HTTP:') do |table|
     }
   )
 
-  lookups = table.hashes.map do |row|
+  @lookup_positions = {}
+  lookups = table.hashes.each_with_index.map do |row, lookup_position|
+    lookup_label = row.fetch('lookup')
+    raise "duplicate lookup label: #{lookup_label}" if @lookup_positions.key?(lookup_label)
+
+    @lookup_positions[lookup_label] = lookup_position
     params = {}
     params[:ip] = row['ip'] unless row['ip'].empty?
     params[:point] = [row['latitude'], row['longitude']] unless row['latitude'].empty? || row['longitude'].empty?
@@ -42,6 +47,21 @@ When('I lookup locations with HTTP:') do |table|
   end
 
   @response = Standort::V2.http.lookup_locations(lookups, opts)
+end
+
+When('I lookup a location using metadata with HTTP:') do |table|
+  @request_id = SecureRandom.uuid
+  rows = table.rows_hash
+  opts = Standort.http_options(
+    headers: {
+      request_id: @request_id, user_agent: 'Standort-ruby-client/2.0 HTTP/1.0',
+      content_type: 'application/pbjson', accept: 'application/pbjson',
+      'x-forwarded-for': rows['ip'], geolocation: rows['geolocation']
+    }
+  )
+
+  @lookup_positions = { rows.fetch('lookup') => 0 }
+  @response = Standort::V2.http.lookup_locations([{}], opts)
 end
 
 When('I lookup {int} locations with HTTP') do |count|
@@ -108,7 +128,7 @@ Then('I should receive batch locations with HTTP:') do |table|
   expect(resp.fetch('meta').fetch('requestId')).to eq(@request_id)
 
   table.hashes.each do |row|
-    lookup = resp.fetch('lookups').fetch(row['index'].to_i)
+    lookup = resp.fetch('lookups').fetch(@lookup_positions.fetch(row['lookup']))
     location = case row['kind']
                when 'ip'
                  expect(lookup['status']).to be_nil
@@ -128,6 +148,30 @@ Then('I should receive batch locations with HTTP:') do |table|
 
     expect(location['country']).to eq(row['country'])
     expect(location['continent']).to eq(row['continent'])
+  end
+end
+
+Then('I should receive batch diagnostics with HTTP:') do |table|
+  expect(@response.code).to eq(200)
+
+  resp = JSON.parse(@response.body)
+
+  expect(resp.fetch('meta').fetch('requestId')).to eq(@request_id)
+
+  table.hashes.group_by { |row| row['lookup'] }.each do |lookup_label, rows|
+    lookup = resp.fetch('lookups').fetch(@lookup_positions.fetch(lookup_label))
+    status = lookup.fetch('status')
+    detail = status.fetch('details').fetch(0)
+    expected_metadata = rows.to_h { |row| [row['diagnostic'], row['code']] }
+
+    expect(lookup['locations']).to be_nil
+    expect(status.fetch('code')).to eq(5)
+    expect(status.fetch('message')).to eq('not found')
+    expect(status.fetch('details').length).to eq(1)
+    expect(detail.fetch('@type')).to eq('type.googleapis.com/google.rpc.ErrorInfo')
+    expect(detail.fetch('reason')).to eq('LOCATION_LOOKUP_FAILED')
+    expect(detail.fetch('domain')).to eq('standort.v2')
+    expect(detail.fetch('metadata')).to eq(expected_metadata)
   end
 end
 

--- a/test/features/v2/transport/grpc/api.feature
+++ b/test/features/v2/transport/grpc/api.feature
@@ -88,15 +88,36 @@ Feature: gRPC API
 
   Scenario: Lookup locations in a batch with gRPC.
     When I lookup locations with gRPC:
-      | kind | ip            | latitude  | longitude |
-      | ip   | 95.91.246.242 |           |           |
-      | geo  |               | 52.377956 |  4.897070 |
-      | none | 192.0.2.1     |           |           |
+      | lookup              | kind | ip            | latitude  | longitude |
+      | German IP address   | ip   | 95.91.246.242 |           |           |
+      | Netherlands point   | geo  |               | 52.377956 |  4.897070 |
+      | unknown IP address  | none | 192.0.2.1     |           |           |
     Then I should receive batch locations with gRPC:
-      | index | kind | country | continent | code |
-      | 0     | ip   | DE      | EU        |      |
-      | 1     | geo  | NL      | EU        |      |
-      | 2     | none |         |           | 5    |
+      | lookup             | kind | country | continent | code |
+      | German IP address  | ip   | DE      | EU        |      |
+      | Netherlands point  | geo  | NL      | EU        |      |
+      | unknown IP address | none |         |           | 5    |
+
+  Scenario: Lookup location failure diagnostics in a batch with gRPC.
+    When I lookup locations with gRPC:
+      | lookup             | kind | ip        | latitude | longitude |
+      | unknown IP address | none | 192.0.2.1 |          |           |
+      | invalid point      | none | 192.0.2.1 |       91 |        10 |
+    Then I should receive batch diagnostics with gRPC:
+      | lookup             | diagnostic             | code          |
+      | unknown IP address | location-ip-error      | not_found     |
+      | invalid point      | location-ip-error      | not_found     |
+      | invalid point      | location-lat-lng-error | invalid_point |
+
+  Scenario: Lookup location metadata failure diagnostics in a batch with gRPC.
+    When I lookup a location using metadata with gRPC:
+      | lookup      | metadata lookup |
+      | ip          | 192.0.2.1    |
+      | geolocation | geo:test,180 |
+    Then I should receive batch diagnostics with gRPC:
+      | lookup           | diagnostic           | code            |
+      | metadata lookup  | location-ip-error    | not_found       |
+      | metadata lookup  | location-point-error | invalid_geo_uri |
 
   Scenario: Lookup too many locations with gRPC.
     When I lookup 101 locations with gRPC

--- a/test/features/v2/transport/http/api.feature
+++ b/test/features/v2/transport/http/api.feature
@@ -88,15 +88,36 @@ Feature: HTTP API
 
   Scenario: Lookup locations in a batch with HTTP.
     When I lookup locations with HTTP:
-      | kind | ip            | latitude  | longitude |
-      | ip   | 95.91.246.242 |           |           |
-      | geo  |               | 52.377956 |  4.897070 |
-      | none | 192.0.2.1     |           |           |
+      | lookup              | kind | ip            | latitude  | longitude |
+      | German IP address   | ip   | 95.91.246.242 |           |           |
+      | Netherlands point   | geo  |               | 52.377956 |  4.897070 |
+      | unknown IP address  | none | 192.0.2.1     |           |           |
     Then I should receive batch locations with HTTP:
-      | index | kind | country | continent | code |
-      | 0     | ip   | DE      | EU        |      |
-      | 1     | geo  | NL      | EU        |      |
-      | 2     | none |         |           | 5    |
+      | lookup             | kind | country | continent | code |
+      | German IP address  | ip   | DE      | EU        |      |
+      | Netherlands point  | geo  | NL      | EU        |      |
+      | unknown IP address | none |         |           | 5    |
+
+  Scenario: Lookup location failure diagnostics in a batch with HTTP.
+    When I lookup locations with HTTP:
+      | lookup             | kind | ip        | latitude | longitude |
+      | unknown IP address | none | 192.0.2.1 |          |           |
+      | invalid point      | none | 192.0.2.1 |       91 |        10 |
+    Then I should receive batch diagnostics with HTTP:
+      | lookup             | diagnostic             | code          |
+      | unknown IP address | location-ip-error      | not_found     |
+      | invalid point      | location-ip-error      | not_found     |
+      | invalid point      | location-lat-lng-error | invalid_point |
+
+  Scenario: Lookup location metadata failure diagnostics in a batch with HTTP.
+    When I lookup a location using metadata with HTTP:
+      | lookup      | metadata lookup |
+      | ip          | 192.0.2.1    |
+      | geolocation | geo:test,180 |
+    Then I should receive batch diagnostics with HTTP:
+      | lookup           | diagnostic           | code            |
+      | metadata lookup  | location-ip-error    | not_found       |
+      | metadata lookup  | location-point-error | invalid_geo_uri |
 
   Scenario: Lookup too many locations with HTTP.
     When I lookup 101 locations with HTTP

--- a/test/lib/standort.rb
+++ b/test/lib/standort.rb
@@ -4,6 +4,8 @@ require 'securerandom'
 require 'yaml'
 require 'base64'
 
+require 'google/rpc/error_details_pb'
+
 require 'standort/v1/http'
 require 'standort/v1/service_pb'
 require 'standort/v1/service_services_pb'


### PR DESCRIPTION
## What

- Return a typed `google.rpc.ErrorInfo` in existing per-entry v2 lookup status details when safe diagnostics are available.
- Preserve the existing response outcome, status code/message, request order, and batch limit while documenting the code-only diagnostic contract.
- Cover HTTP protobuf JSON and gRPC clients with descriptive lookup labels rather than ordinal fixture positions.

## Why

- Lets batch API clients distinguish safe lookup causes without parsing a generic miss or receiving raw request/provider errors.
- Keeps existing generated clients compatible by using the established `google.rpc.Status.details` extension point.

## Testing

- `make proto-format` - passed
- `make proto-generate` - passed
- `make proto-breaking` - passed
- `make features` - passed (129 scenarios, 258 steps)
- `make lint` - passed
- `make sec` - passed (govulncheck found no called vulnerability; Trivy found no Go or Ruby dependency vulnerability)
- `make analyse` - passed
- `make specs` - passed (0 Go tests discovered)
- `make coverage` - local report merger could not run because `test/reports` contained no coverage profiles after the feature harness; CI coverage remains required.
- `make proto-stale` - not run because its whole-worktree `git diff` check treats the intended uncommitted PR diff as stale; `make proto-generate` completed successfully.

AI-assisted-by: [Codex](https://openai.com/codex/)
