### PR TITLE
feat(location): distinguish invalid ip diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,12 @@ This repository is a Go service called **standort** (location-based information)
   CircleCI workflow as a reliability gap unless there is concrete evidence that
   the infraops deployment path no longer controls the deployed state or can roll
   it back out of order.
+- v2 intentionally combines explicitly supplied lookup inputs with ambient
+  transport metadata for any omitted source. Its separate `ip` and `geo`
+  response fields identify those independent lookup results. Do not propose an
+  explicit-input-only switch or treat this metadata fallback as a feature,
+  reliability, or API-design gap unless evidence shows this contract has
+  changed.
 
 ## First steps
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ v2 response fields are independent:
 - both fields are populated when both inputs succeed.
 - on partial success, the successful field is returned without failed-side diagnostics.
 
-Terminal lookup failures return gRPC `NotFound`; the HTTP RPC router exposes the same lookup miss as HTTP `404`. v2 transports may attach code-only diagnostics to the terminal error metadata, using `location-ip-error`, `location-lat-lng-error`, or `location-point-error`.
+Terminal lookup failures return gRPC `NotFound`; the HTTP RPC router exposes the same lookup miss as HTTP `404`. v2 transports may attach code-only diagnostics to the terminal error metadata, using `location-ip-error`, `location-lat-lng-error`, or `location-point-error`. A malformed IP uses `location-ip-error: invalid_ip`; a syntactically valid address that has no dataset match uses `location-ip-error: not_found`.
 
 `LookupLocations` accepts up to 100 lookup entries and preserves request order
 in the response. Each entry returns one outcome: successful entries populate

--- a/internal/api/location/location.go
+++ b/internal/api/location/location.go
@@ -129,7 +129,7 @@ func (s *Locator) Locate(ctx context.Context, ip string, p *Point) (*Locations, 
 
 	if ip := s.ip(ctx, ip); !strings.IsEmpty(ip) {
 		if country, continent, err := s.location.GetByIP(ctx, ip); err != nil {
-			diag = diagnostics.IPError(diag, diagnostics.NotFound)
+			diag = diagnostics.IPError(diag, ipErrorCode(err))
 		} else {
 			locations.IP = &Location{Country: country, Continent: continent, Kind: IP}
 		}
@@ -177,6 +177,14 @@ func (s *Locator) point(ctx context.Context, p *Point) (*Point, error) {
 	}
 
 	return &Point{Lat: geo.Latitude, Lng: geo.Longitude}, nil
+}
+
+func ipErrorCode(err error) diagnostics.Code {
+	if errors.Is(err, location.ErrInvalidIP) {
+		return diagnostics.InvalidIP
+	}
+
+	return diagnostics.NotFound
 }
 
 func locationErrorCode(err error) diagnostics.Code {

--- a/internal/diagnostics/diagnostics.go
+++ b/internal/diagnostics/diagnostics.go
@@ -18,6 +18,9 @@ type Code string
 // NotFound reports a lookup miss.
 const NotFound Code = "not_found"
 
+// InvalidIP reports an IP address that is not valid IPv4 or IPv6.
+const InvalidIP Code = "invalid_ip"
+
 // InvalidPoint reports latitude/longitude outside the supported coordinate range.
 const InvalidPoint Code = "invalid_point"
 

--- a/internal/location/location.go
+++ b/internal/location/location.go
@@ -3,6 +3,7 @@ package location
 import (
 	"fmt"
 	"math"
+	"net"
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
@@ -12,6 +13,9 @@ import (
 	ip "github.com/alexfalkowski/standort/v2/internal/location/ip/provider"
 	orb "github.com/alexfalkowski/standort/v2/internal/location/orb/provider"
 )
+
+// ErrInvalidIP is returned when an IP address is not a valid IPv4 or IPv6 address.
+var ErrInvalidIP = errors.New("invalid ip")
 
 // ErrInvalidPoint is returned when latitude or longitude is non-finite or outside
 // the supported geographic coordinate range.
@@ -54,6 +58,10 @@ type Location struct {
 // It returns `(countryCode, continentCode, error)`. On error, both returned
 // strings are empty.
 func (l *Location) GetByIP(ctx context.Context, ip string) (string, string, error) {
+	if net.ParseIP(ip) == nil {
+		return strings.Empty, strings.Empty, ErrInvalidIP
+	}
+
 	c, err := l.ipProvider.GetByIP(ctx, ip)
 	if err != nil {
 		return strings.Empty, strings.Empty, err

--- a/test/features/v2/transport/grpc/api.feature
+++ b/test/features/v2/transport/grpc/api.feature
@@ -13,17 +13,17 @@ Feature: gRPC API
 
     Examples: With geoip2 parameters
       | source | method | kind | ip                                      | country | continent |
-      | geoip2 | params | ip   |                           95.91.246.242 | DE      | EU        |
-      | geoip2 | params | ip   |                          45.128.199.236 | NL      | EU        |
-      | geoip2 | params | ip   |                             154.6.22.65 | US      | NA        |
-      | geoip2 | params | ip   |                                1.40.0.0 | AU      | OC        |
+      | geoip2 | params | ip   | 95.91.246.242                           | DE      | EU        |
+      | geoip2 | params | ip   | 45.128.199.236                          | NL      | EU        |
+      | geoip2 | params | ip   | 154.6.22.65                             | US      | NA        |
+      | geoip2 | params | ip   | 1.40.0.0                                | AU      | OC        |
       | geoip2 | params | ip   | 2a02:8109:9f2e:4600:861e:b845:8bd4:b047 | DE      | EU        |
 
     Examples: With geoip2 metadata
       | source | method   | kind | ip             | country | continent |
-      | geoip2 | metadata | ip   |  95.91.246.242 | DE      | EU        |
+      | geoip2 | metadata | ip   | 95.91.246.242  | DE      | EU        |
       | geoip2 | metadata | ip   | 45.128.199.236 | NL      | EU        |
-      | geoip2 | metadata | ip   |    154.6.22.65 | US      | NA        |
+      | geoip2 | metadata | ip   | 154.6.22.65    | US      | NA        |
 
   Scenario Outline: Get location by a not found IP address.
     When I request a location with gRPC:
@@ -34,20 +34,22 @@ Feature: gRPC API
       | code       | <code>       |
 
     Examples: With geoip2 parameters
-      | source | method | ip        | diagnostic        | code      |
-      | geoip2 | params | 0.0.0.0   | location-ip-error | not_found |
-      | geoip2 | params | test      | location-ip-error | not_found |
-      | geoip2 | params | <test>    | location-ip-error | not_found |
-      | geoip2 | params | 154.6     | location-ip-error | not_found |
-      | geoip2 | params | 192.0.2.1 | location-ip-error | not_found |
+      | source | method | ip           | diagnostic        | code       |
+      | geoip2 | params | 0.0.0.0      | location-ip-error | not_found  |
+      | geoip2 | params | test         | location-ip-error | invalid_ip |
+      | geoip2 | params | <test>       | location-ip-error | invalid_ip |
+      | geoip2 | params | 154.6        | location-ip-error | invalid_ip |
+      | geoip2 | params | 2001:db8::zz | location-ip-error | invalid_ip |
+      | geoip2 | params | 192.0.2.1    | location-ip-error | not_found  |
 
     Examples: With geoip2 metadata
-      | source | method   | ip        | diagnostic        | code      |
-      | geoip2 | metadata | 0.0.0.0   | location-ip-error | not_found |
-      | geoip2 | metadata | test      | location-ip-error | not_found |
-      | geoip2 | metadata | <test>    | location-ip-error | not_found |
-      | geoip2 | metadata | 154.6     | location-ip-error | not_found |
-      | geoip2 | metadata | 192.0.2.1 | location-ip-error | not_found |
+      | source | method   | ip           | diagnostic        | code       |
+      | geoip2 | metadata | 0.0.0.0      | location-ip-error | not_found  |
+      | geoip2 | metadata | test         | location-ip-error | invalid_ip |
+      | geoip2 | metadata | <test>       | location-ip-error | invalid_ip |
+      | geoip2 | metadata | 154.6        | location-ip-error | invalid_ip |
+      | geoip2 | metadata | 2001:db8::zz | location-ip-error | invalid_ip |
+      | geoip2 | metadata | 192.0.2.1    | location-ip-error | not_found  |
 
   Scenario Outline: Get location by a valid latitude and longitude.
     When I request a location with gRPC:
@@ -61,14 +63,14 @@ Feature: gRPC API
 
     Examples: With parameters
       | method | kind | latitude  | longitude  | country | continent |
-      | params | geo  | 52.520008 |  13.404954 | DE      | EU        |
-      | params | geo  | 52.377956 |   4.897070 | NL      | EU        |
+      | params | geo  | 52.520008 | 13.404954  | DE      | EU        |
+      | params | geo  | 52.377956 | 4.897070   | NL      | EU        |
       | params | geo  | 43.000000 | -75.000000 | US      | NA        |
 
     Examples: With metadata
       | method   | kind | latitude  | longitude  | country | continent |
-      | metadata | geo  | 52.520008 |  13.404954 | DE      | EU        |
-      | metadata | geo  | 52.377956 |   4.897070 | NL      | EU        |
+      | metadata | geo  | 52.520008 | 13.404954  | DE      | EU        |
+      | metadata | geo  | 52.377956 | 4.897070   | NL      | EU        |
       | metadata | geo  | 43.000000 | -75.000000 | US      | NA        |
 
   Scenario Outline: Get location by a valid IP address and latitude and longitude.
@@ -84,14 +86,14 @@ Feature: gRPC API
 
     Examples: With parameters
       | method | ip            | latitude  | longitude | ip_country | ip_continent | geo_country | geo_continent |
-      | params | 95.91.246.242 | 52.377956 |  4.897070 | DE         | EU           | NL          | EU            |
+      | params | 95.91.246.242 | 52.377956 | 4.897070  | DE         | EU           | NL          | EU            |
 
   Scenario: Lookup locations in a batch with gRPC.
     When I lookup locations with gRPC:
-      | lookup              | kind | ip            | latitude  | longitude |
-      | German IP address   | ip   | 95.91.246.242 |           |           |
-      | Netherlands point   | geo  |               | 52.377956 |  4.897070 |
-      | unknown IP address  | none | 192.0.2.1     |           |           |
+      | lookup             | kind | ip            | latitude  | longitude |
+      | German IP address  | ip   | 95.91.246.242 |           |           |
+      | Netherlands point  | geo  |               | 52.377956 | 4.897070  |
+      | unknown IP address | none | 192.0.2.1     |           |           |
     Then I should receive batch locations with gRPC:
       | lookup             | kind | country | continent | code |
       | German IP address  | ip   | DE      | EU        |      |
@@ -102,22 +104,22 @@ Feature: gRPC API
     When I lookup locations with gRPC:
       | lookup             | kind | ip        | latitude | longitude |
       | unknown IP address | none | 192.0.2.1 |          |           |
-      | invalid point      | none | 192.0.2.1 |       91 |        10 |
+      | invalid point      | none | 154.6     | 91       | 10        |
     Then I should receive batch diagnostics with gRPC:
       | lookup             | diagnostic             | code          |
       | unknown IP address | location-ip-error      | not_found     |
-      | invalid point      | location-ip-error      | not_found     |
+      | invalid point      | location-ip-error      | invalid_ip    |
       | invalid point      | location-lat-lng-error | invalid_point |
 
   Scenario: Lookup location metadata failure diagnostics in a batch with gRPC.
     When I lookup a location using metadata with gRPC:
       | lookup      | metadata lookup |
-      | ip          | 192.0.2.1    |
-      | geolocation | geo:test,180 |
+      | ip          | 192.0.2.1       |
+      | geolocation | geo:test,180    |
     Then I should receive batch diagnostics with gRPC:
-      | lookup           | diagnostic           | code            |
-      | metadata lookup  | location-ip-error    | not_found       |
-      | metadata lookup  | location-point-error | invalid_geo_uri |
+      | lookup          | diagnostic           | code            |
+      | metadata lookup | location-ip-error    | not_found       |
+      | metadata lookup | location-point-error | invalid_geo_uri |
 
   Scenario: Lookup too many locations with gRPC.
     When I lookup 101 locations with gRPC
@@ -143,12 +145,14 @@ Feature: gRPC API
 
     Examples: With parameters
       | method | kind | ip            | latitude  | longitude | country | continent |
-      | params | geo  | 0.0.0.0       | 52.377956 |  4.897070 | NL      | EU        |
+      | params | geo  | 0.0.0.0       | 52.377956 | 4.897070  | NL      | EU        |
+      | params | geo  | test          | 52.377956 | 4.897070  | NL      | EU        |
       | params | ip   | 95.91.246.242 | 91        | 10        | DE      | EU        |
 
     Examples: With metadata
-      | method   | kind | ip            | latitude | longitude | country | continent |
-      | metadata | ip   | 95.91.246.242 | test     | 180       | DE      | EU        |
+      | method   | kind | ip            | latitude  | longitude | country | continent |
+      | metadata | geo  | test          | 52.377956 | 4.897070  | NL      | EU        |
+      | metadata | ip   | 95.91.246.242 | test      | 180       | DE      | EU        |
 
   Scenario Outline: Get location by a bad latitude and longitude.
     When I request a location with gRPC:
@@ -161,17 +165,17 @@ Feature: gRPC API
 
     Examples: With parameters
       | method | latitude | longitude | diagnostic             | code          |
-      | params |       91 |        10 | location-lat-lng-error | invalid_point |
-      | params |       10 |       181 | location-lat-lng-error | invalid_point |
-      | params |      nan |        10 | location-lat-lng-error | invalid_point |
-      | params |       10 |       inf | location-lat-lng-error | invalid_point |
+      | params | 91       | 10        | location-lat-lng-error | invalid_point |
+      | params | 10       | 181       | location-lat-lng-error | invalid_point |
+      | params | nan      | 10        | location-lat-lng-error | invalid_point |
+      | params | 10       | inf       | location-lat-lng-error | invalid_point |
 
     Examples: With metadata
       | method   | latitude | longitude | diagnostic             | code            |
-      | metadata |       91 |        10 | location-lat-lng-error | invalid_point   |
-      | metadata |       10 |       181 | location-lat-lng-error | invalid_point   |
-      | metadata | test     |       180 | location-point-error   | invalid_geo_uri |
-      | metadata |       90 | test      | location-point-error   | invalid_geo_uri |
+      | metadata | 91       | 10        | location-lat-lng-error | invalid_point   |
+      | metadata | 10       | 181       | location-lat-lng-error | invalid_point   |
+      | metadata | test     | 180       | location-point-error   | invalid_geo_uri |
+      | metadata | 90       | test      | location-point-error   | invalid_geo_uri |
 
   Scenario Outline: Get location by a not found latitude and longitude.
     When I request a location with gRPC:

--- a/test/features/v2/transport/http/api.feature
+++ b/test/features/v2/transport/http/api.feature
@@ -13,17 +13,17 @@ Feature: HTTP API
 
     Examples: With geoip2 parameters
       | source | method | kind | ip             | country | continent |
-      | geoip2 | params | ip   |  95.91.246.242 | DE      | EU        |
+      | geoip2 | params | ip   | 95.91.246.242  | DE      | EU        |
       | geoip2 | params | ip   | 45.128.199.236 | NL      | EU        |
-      | geoip2 | params | ip   |    154.6.22.65 | US      | NA        |
-      | geoip2 | params | ip   |       1.40.0.0 | AU      | OC        |
+      | geoip2 | params | ip   | 154.6.22.65    | US      | NA        |
+      | geoip2 | params | ip   | 1.40.0.0       | AU      | OC        |
 
     Examples: With geoip2 headers
       | source | method  | kind | ip             | country | continent |
-      | geoip2 | headers | ip   |  95.91.246.242 | DE      | EU        |
+      | geoip2 | headers | ip   | 95.91.246.242  | DE      | EU        |
       | geoip2 | headers | ip   | 45.128.199.236 | NL      | EU        |
-      | geoip2 | headers | ip   |    154.6.22.65 | US      | NA        |
-      | geoip2 | headers | ip   |       1.40.0.0 | AU      | OC        |
+      | geoip2 | headers | ip   | 154.6.22.65    | US      | NA        |
+      | geoip2 | headers | ip   | 1.40.0.0       | AU      | OC        |
 
   Scenario Outline: Get location by an bad IP address.
     When I request a location with HTTP:
@@ -34,20 +34,22 @@ Feature: HTTP API
       | code       | <code>       |
 
     Examples: With geoip2 parameters
-      | source | method | ip        | diagnostic        | code      |
-      | geoip2 | params | 0.0.0.0   | location-ip-error | not_found |
-      | geoip2 | params | test      | location-ip-error | not_found |
-      | geoip2 | params | <test>    | location-ip-error | not_found |
-      | geoip2 | params | 154.6     | location-ip-error | not_found |
-      | geoip2 | params | 192.0.2.1 | location-ip-error | not_found |
+      | source | method | ip           | diagnostic        | code       |
+      | geoip2 | params | 0.0.0.0      | location-ip-error | not_found  |
+      | geoip2 | params | test         | location-ip-error | invalid_ip |
+      | geoip2 | params | <test>       | location-ip-error | invalid_ip |
+      | geoip2 | params | 154.6        | location-ip-error | invalid_ip |
+      | geoip2 | params | 2001:db8::zz | location-ip-error | invalid_ip |
+      | geoip2 | params | 192.0.2.1    | location-ip-error | not_found  |
 
     Examples: With geoip2 headers
-      | source | method  | ip        | diagnostic        | code      |
-      | geoip2 | headers | 0.0.0.0   | location-ip-error | not_found |
-      | geoip2 | headers | test      | location-ip-error | not_found |
-      | geoip2 | headers | <test>    | location-ip-error | not_found |
-      | geoip2 | headers | 154.6     | location-ip-error | not_found |
-      | geoip2 | headers | 192.0.2.1 | location-ip-error | not_found |
+      | source | method  | ip           | diagnostic        | code       |
+      | geoip2 | headers | 0.0.0.0      | location-ip-error | not_found  |
+      | geoip2 | headers | test         | location-ip-error | invalid_ip |
+      | geoip2 | headers | <test>       | location-ip-error | invalid_ip |
+      | geoip2 | headers | 154.6        | location-ip-error | invalid_ip |
+      | geoip2 | headers | 2001:db8::zz | location-ip-error | invalid_ip |
+      | geoip2 | headers | 192.0.2.1    | location-ip-error | not_found  |
 
   Scenario Outline: Get location by a valid latitude and longitude.
     When I request a location with HTTP:
@@ -61,14 +63,14 @@ Feature: HTTP API
 
     Examples: With parameters
       | method | kind | latitude  | longitude  | country | continent |
-      | params | geo  | 52.520008 |  13.404954 | DE      | EU        |
-      | params | geo  | 52.377956 |   4.897070 | NL      | EU        |
+      | params | geo  | 52.520008 | 13.404954  | DE      | EU        |
+      | params | geo  | 52.377956 | 4.897070   | NL      | EU        |
       | params | geo  | 43.000000 | -75.000000 | US      | NA        |
 
     Examples: With headers
       | method  | kind | latitude  | longitude  | country | continent |
-      | headers | geo  | 52.520008 |  13.404954 | DE      | EU        |
-      | headers | geo  | 52.377956 |   4.897070 | NL      | EU        |
+      | headers | geo  | 52.520008 | 13.404954  | DE      | EU        |
+      | headers | geo  | 52.377956 | 4.897070   | NL      | EU        |
       | headers | geo  | 43.000000 | -75.000000 | US      | NA        |
 
   Scenario Outline: Get location by a valid IP address and latitude and longitude.
@@ -84,14 +86,14 @@ Feature: HTTP API
 
     Examples: With parameters
       | method | ip            | latitude  | longitude | ip_country | ip_continent | geo_country | geo_continent |
-      | params | 95.91.246.242 | 52.377956 |  4.897070 | DE         | EU           | NL          | EU            |
+      | params | 95.91.246.242 | 52.377956 | 4.897070  | DE         | EU           | NL          | EU            |
 
   Scenario: Lookup locations in a batch with HTTP.
     When I lookup locations with HTTP:
-      | lookup              | kind | ip            | latitude  | longitude |
-      | German IP address   | ip   | 95.91.246.242 |           |           |
-      | Netherlands point   | geo  |               | 52.377956 |  4.897070 |
-      | unknown IP address  | none | 192.0.2.1     |           |           |
+      | lookup             | kind | ip            | latitude  | longitude |
+      | German IP address  | ip   | 95.91.246.242 |           |           |
+      | Netherlands point  | geo  |               | 52.377956 | 4.897070  |
+      | unknown IP address | none | 192.0.2.1     |           |           |
     Then I should receive batch locations with HTTP:
       | lookup             | kind | country | continent | code |
       | German IP address  | ip   | DE      | EU        |      |
@@ -102,22 +104,22 @@ Feature: HTTP API
     When I lookup locations with HTTP:
       | lookup             | kind | ip        | latitude | longitude |
       | unknown IP address | none | 192.0.2.1 |          |           |
-      | invalid point      | none | 192.0.2.1 |       91 |        10 |
+      | invalid point      | none | 154.6     | 91       | 10        |
     Then I should receive batch diagnostics with HTTP:
       | lookup             | diagnostic             | code          |
       | unknown IP address | location-ip-error      | not_found     |
-      | invalid point      | location-ip-error      | not_found     |
+      | invalid point      | location-ip-error      | invalid_ip    |
       | invalid point      | location-lat-lng-error | invalid_point |
 
   Scenario: Lookup location metadata failure diagnostics in a batch with HTTP.
     When I lookup a location using metadata with HTTP:
       | lookup      | metadata lookup |
-      | ip          | 192.0.2.1    |
-      | geolocation | geo:test,180 |
+      | ip          | 192.0.2.1       |
+      | geolocation | geo:test,180    |
     Then I should receive batch diagnostics with HTTP:
-      | lookup           | diagnostic           | code            |
-      | metadata lookup  | location-ip-error    | not_found       |
-      | metadata lookup  | location-point-error | invalid_geo_uri |
+      | lookup          | diagnostic           | code            |
+      | metadata lookup | location-ip-error    | not_found       |
+      | metadata lookup | location-point-error | invalid_geo_uri |
 
   Scenario: Lookup too many locations with HTTP.
     When I lookup 101 locations with HTTP
@@ -143,12 +145,14 @@ Feature: HTTP API
 
     Examples: With parameters
       | method | kind | ip            | latitude  | longitude | country | continent |
-      | params | geo  |       0.0.0.0 | 52.377956 |  4.897070 | NL      | EU        |
-      | params | ip   | 95.91.246.242 |        91 |        10 | DE      | EU        |
+      | params | geo  | 0.0.0.0       | 52.377956 | 4.897070  | NL      | EU        |
+      | params | geo  | test          | 52.377956 | 4.897070  | NL      | EU        |
+      | params | ip   | 95.91.246.242 | 91        | 10        | DE      | EU        |
 
     Examples: With headers
-      | method  | kind | ip            | latitude | longitude | country | continent |
-      | headers | ip   | 95.91.246.242 | test     |       180 | DE      | EU        |
+      | method  | kind | ip            | latitude  | longitude | country | continent |
+      | headers | geo  | test          | 52.377956 | 4.897070  | NL      | EU        |
+      | headers | ip   | 95.91.246.242 | test      | 180       | DE      | EU        |
 
   Scenario Outline: Get location by a bad latitude and longitude.
     When I request a location with HTTP:
@@ -161,15 +165,15 @@ Feature: HTTP API
 
     Examples: With parameters
       | method | latitude | longitude | diagnostic             | code          |
-      | params |       91 |        10 | location-lat-lng-error | invalid_point |
-      | params |       10 |       181 | location-lat-lng-error | invalid_point |
+      | params | 91       | 10        | location-lat-lng-error | invalid_point |
+      | params | 10       | 181       | location-lat-lng-error | invalid_point |
 
     Examples: With headers
       | method  | latitude | longitude | diagnostic             | code            |
-      | headers |       91 |        10 | location-lat-lng-error | invalid_point   |
-      | headers |       10 |       181 | location-lat-lng-error | invalid_point   |
-      | headers | test     |       180 | location-point-error   | invalid_geo_uri |
-      | headers |       90 | test      | location-point-error   | invalid_geo_uri |
+      | headers | 91       | 10        | location-lat-lng-error | invalid_point   |
+      | headers | 10       | 181       | location-lat-lng-error | invalid_point   |
+      | headers | test     | 180       | location-point-error   | invalid_geo_uri |
+      | headers | 90       | test      | location-point-error   | invalid_geo_uri |
 
   Scenario Outline: Get location by a not found latitude and longitude.
     When I request a location with HTTP:
@@ -182,7 +186,7 @@ Feature: HTTP API
 
     Examples:
       | method  | latitude   | longitude | diagnostic             | code      |
-      | params  |         90 |       180 | location-lat-lng-error | not_found |
-      | headers |         90 |       180 | location-lat-lng-error | not_found |
+      | params  | 90         | 180       | location-lat-lng-error | not_found |
+      | headers | 90         | 180       | location-lat-lng-error | not_found |
       | params  | -49.303721 | 69.122136 | location-lat-lng-error | not_found |
       | headers | -49.303721 | 69.122136 | location-lat-lng-error | not_found |


### PR DESCRIPTION
## What

- Distinguish malformed IPv4 and IPv6 inputs from valid GeoIP lookup misses with the safe `location-ip-error: invalid_ip` diagnostic while preserving existing HTTP/gRPC status codes and response shapes.
- Extend explicit and metadata lookup scenarios, batch diagnostic metadata, partial-success coverage, and documentation; align all v2 feature-table columns for readability.
- Include the repository guidance that documents v2's intentional metadata fallback behavior.

## Why

- API consumers can now correct malformed records instead of treating them as ordinary dataset misses, without exposing parser/provider errors or changing the established NotFound/404 contract.

## Testing

- `make features` - passed (137 scenarios, including v1 and v2 transport coverage).
- `make specs` - passed (the repository currently reports 0 Go tests).
- `make lint` - passed (0 issues; 16 Ruby files inspected).
- `git diff --check` - passed.

AI-assisted-by: [Codex](https://openai.com/codex/)
