### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.663.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	git.jlel.se/jlelse/go-geouri v0.0.0-20210525190615-a9c1d50f42d6
 	github.com/IncSW/geoip2 v0.1.4
 	github.com/alexfalkowski/go-health/v2 v2.35.0
-	github.com/alexfalkowski/go-service/v2 v2.662.0
+	github.com/alexfalkowski/go-service/v2 v2.663.0
 	github.com/pariz/gountries v0.1.6
 	github.com/paulmach/orb v0.13.0
 	github.com/tidwall/rtree v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.35.0 h1:Fw2VcXuzFFu3nNLZ899KwNH7MgqttJ1i9cQDwPvk1/E=
 github.com/alexfalkowski/go-health/v2 v2.35.0/go.mod h1:JgnHd/ajgMgxqZ5RNU3gEohFyi6qS5SJ5gXHN2YYDe4=
-github.com/alexfalkowski/go-service/v2 v2.662.0 h1:7pSv7Ql+kb3qMdm9wj+MzAHHFUOx4uc08LdeeSCy230=
-github.com/alexfalkowski/go-service/v2 v2.662.0/go.mod h1:agLjz94+/BWqIOcUXJCHYcU8dQtzDDlnt+ma6TFvMbI=
+github.com/alexfalkowski/go-service/v2 v2.663.0 h1:3/oamxkDpPKzXT86Od1QTYPeSbY8xAhZhHtfXDLpPWI=
+github.com/alexfalkowski/go-service/v2 v2.663.0/go.mod h1:EG7wsMPc1XAO4X+jLkyJaQVsJZuGbDs9a32T/r8twgw=
 github.com/alexfalkowski/go-sync v1.30.0 h1:DcNUSV9UgZGIkxE9SJiQcUgdmd1AANK+qeoQmSJsf4k=
 github.com/alexfalkowski/go-sync v1.30.0/go.mod h1:IzEbtMNtoLHdIfoO6Z+f7azto4wjLuj6ZgAOrpKLZbY=
 github.com/arl/statsviz v0.8.1 h1:9Ns7GBWCPWn46M/KfqZ5BqRxU578e/MV7/DOwpt2Sd8=


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.663.0
