### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.670.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	git.jlel.se/jlelse/go-geouri v0.0.0-20210525190615-a9c1d50f42d6
 	github.com/IncSW/geoip2 v0.1.4
 	github.com/alexfalkowski/go-health/v2 v2.36.0
-	github.com/alexfalkowski/go-service/v2 v2.669.0
+	github.com/alexfalkowski/go-service/v2 v2.670.0
 	github.com/pariz/gountries v0.1.6
 	github.com/paulmach/orb v0.13.0
 	github.com/tidwall/rtree v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.36.0 h1:hnvNgJPtBerVZMrvL+FKj8iSHObnPHBKbTV41Ag0ONs=
 github.com/alexfalkowski/go-health/v2 v2.36.0/go.mod h1:60p9Msqbv3LR0t23WlNqXdzQEsWnl/zA6Y/LHUQ2e1o=
-github.com/alexfalkowski/go-service/v2 v2.669.0 h1:Cg1kOgQ+xEBySUMkyaGUrBEIEa3SBYQ5GX2SGY8aEZ4=
-github.com/alexfalkowski/go-service/v2 v2.669.0/go.mod h1:f6mIp00PU0LWglz+MNepD1L2dSp9SPTlNos7C/HJPKA=
+github.com/alexfalkowski/go-service/v2 v2.670.0 h1:d9h2CugljzW+D9DZER/WsY88TDKK//7BILvoC8dkf1s=
+github.com/alexfalkowski/go-service/v2 v2.670.0/go.mod h1:f6mIp00PU0LWglz+MNepD1L2dSp9SPTlNos7C/HJPKA=
 github.com/alexfalkowski/go-sync v1.32.0 h1:krvQ2BPzq5NcU+24XhSK0YN+lP+Wd6OlOg6Aq6s7wY4=
 github.com/alexfalkowski/go-sync v1.32.0/go.mod h1:IzEbtMNtoLHdIfoO6Z+f7azto4wjLuj6ZgAOrpKLZbY=
 github.com/arl/statsviz v0.8.1 h1:9Ns7GBWCPWn46M/KfqZ5BqRxU578e/MV7/DOwpt2Sd8=


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.670.0
