### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.693.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	git.jlel.se/jlelse/go-geouri v0.0.0-20210525190615-a9c1d50f42d6
 	github.com/IncSW/geoip2 v0.1.4
 	github.com/alexfalkowski/go-health/v2 v2.37.0
-	github.com/alexfalkowski/go-service/v2 v2.692.0
+	github.com/alexfalkowski/go-service/v2 v2.693.0
 	github.com/pariz/gountries v0.1.6
 	github.com/paulmach/orb v0.13.0
 	github.com/tidwall/rtree v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.37.0 h1:UItNzlTyEafq5MoqaHpMxYqXAHzqL6Cpjb9wujPedL0=
 github.com/alexfalkowski/go-health/v2 v2.37.0/go.mod h1:t6fhN4YxTB26TSnKUjLyjZFRbKv4EkBwinWd/fFn4Us=
-github.com/alexfalkowski/go-service/v2 v2.692.0 h1:gcdaZTDb2VAddtdZgG+EdUMyWvl+x4gYoeCwyLHMVmY=
-github.com/alexfalkowski/go-service/v2 v2.692.0/go.mod h1:ri5v3PU1aPLngqKQwczWqxAl2a8HTcsHLBizDdxdaNg=
+github.com/alexfalkowski/go-service/v2 v2.693.0 h1:+A4vxdBxLLuuPB3GD0MiszW01dwvcSpHgx1VyL4iBGM=
+github.com/alexfalkowski/go-service/v2 v2.693.0/go.mod h1:ri5v3PU1aPLngqKQwczWqxAl2a8HTcsHLBizDdxdaNg=
 github.com/alexfalkowski/go-sync v1.33.0 h1:XN5XUFJ/w/emDUJ0CXZOZl6UVTkx/zj0y6kaFWIHbk8=
 github.com/alexfalkowski/go-sync v1.33.0/go.mod h1:IzEbtMNtoLHdIfoO6Z+f7azto4wjLuj6ZgAOrpKLZbY=
 github.com/arl/statsviz v0.8.1 h1:9Ns7GBWCPWn46M/KfqZ5BqRxU578e/MV7/DOwpt2Sd8=

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
     mustermann (3.1.1)
     netrc (0.11.0)
     nio4r (2.7.5)
-    nonnative (3.36.0)
+    nonnative (3.38.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.693.0
